### PR TITLE
feat: add dashboard asset summary cards

### DIFF
--- a/frontend/src/components/CategoryBreakdown.tsx
+++ b/frontend/src/components/CategoryBreakdown.tsx
@@ -1,0 +1,27 @@
+type CategoryBreakdownProps = {
+  categories: Record<string, number>;
+};
+
+const CategoryBreakdown = ({ categories }: CategoryBreakdownProps) => {
+  const items = Object.entries(categories);
+
+  return (
+    <section className="dashboard-panel">
+      <h2>Category Breakdown</h2>
+      {items.length === 0 ? (
+        <p>No categories yet</p>
+      ) : (
+        <ul className="category-breakdown-list">
+          {items.map(([category, count]) => (
+            <li key={category}>
+              <span>{category}</span>
+              <strong>{count}</strong>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default CategoryBreakdown;

--- a/frontend/src/components/DashboardSummaryCards.tsx
+++ b/frontend/src/components/DashboardSummaryCards.tsx
@@ -1,0 +1,33 @@
+type DashboardSummaryCardsProps = {
+  totalAssets: number;
+  availableCount: number;
+  assignedCount: number;
+  maintenanceCount: number;
+};
+
+const DashboardSummaryCards = ({
+  totalAssets,
+  availableCount,
+  assignedCount,
+  maintenanceCount,
+}: DashboardSummaryCardsProps) => {
+  const cards = [
+    { label: "Total assets", value: totalAssets, color: "bg-blue-500" },
+    { label: "Available", value: availableCount, color: "bg-green-500" },
+    { label: "Assigned", value: assignedCount, color: "bg-yellow-500" },
+    { label: "Maintenance", value: maintenanceCount, color: "bg-red-500" },
+  ];
+
+  return (
+    <div className="dashboard-cards">
+      {cards.map((card) => (
+        <div className={`dashboard-card ${card.color}`} key={card.label}>
+          <p>{card.label}</p>
+          <strong>{card.value}</strong>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DashboardSummaryCards;

--- a/frontend/src/components/RecentlyAddedAssets.tsx
+++ b/frontend/src/components/RecentlyAddedAssets.tsx
@@ -1,0 +1,28 @@
+import type { Asset } from "../types/asset.types";
+
+type RecentlyAddedAssetsProps = {
+  assets: Asset[];
+};
+
+const RecentlyAddedAssets = ({ assets }: RecentlyAddedAssetsProps) => {
+  return (
+    <section className="dashboard-panel">
+      <h2>Recently Added Assets</h2>
+
+      {assets.length === 0 ? (
+        <p>No assets added recently</p>
+      ) : (
+        <ul className="recently-added-assets-list">
+          {assets.map((asset) => (
+            <li key={asset._id}>
+              <span>{asset.name}</span>
+              <small>{asset.category}</small>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default RecentlyAddedAssets;

--- a/frontend/src/hooks/useDashboardStats.ts
+++ b/frontend/src/hooks/useDashboardStats.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import type { Asset } from "../types/asset.types";
+
+export const useDashboardStats = (assets: Asset[]) => {
+  return useMemo(() => {
+    const totalAssets = assets.length;
+    const availableCount = assets.filter(
+      (asset) => asset.status === "available",
+    ).length;
+    const assignedCount = assets.filter(
+      (asset) => asset.status === "assigned",
+    ).length;
+    const maintenanceCount = assets.filter(
+      (asset) => asset.status === "maintenance",
+    ).length;
+    const categoryBreakdown = assets.reduce<Record<string, number>>(
+      (acc, asset) => {
+        const category = asset.category || "Uncategorized";
+        acc[category] = (acc[category] || 0) + 1;
+        return acc;
+      },
+      {},
+    );
+
+    const recentlyAddedAssets = [...assets]
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt ?? "").getTime() -
+          new Date(a.createdAt ?? "").getTime(),
+      )
+      .slice(0, 5);
+
+    return {
+      totalAssets,
+      availableCount,
+      assignedCount,
+      maintenanceCount,
+      categoryBreakdown,
+      recentlyAddedAssets,
+    };
+  }, [assets]);
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,12 +6,25 @@ import { AssetForm } from "../components/AssetForm";
 import { AssetFilter } from "../components/AssetFilter";
 import { AssetTable } from "../components/AssetTable";
 import type { NewAsset } from "../types/asset.types";
+import { useDashboardStats } from "../hooks/useDashboardStats";
+import DashboardSummaryCards from "../components/DashboardSummaryCards";
+import RecentlyAddedAssets from "../components/RecentlyAddedAssets";
+import CategoryBreakdown from "../components/CategoryBreakdown";
 
 const DashboardPage = () => {
   const { logout } = useAuth();
   const { assets, loading, loadAssets, addAsset, removeAsset, editAsset } =
     useAssets();
   const [showForm, setShowForm] = useState(false);
+
+  const {
+    totalAssets,
+    availableCount,
+    assignedCount,
+    maintenanceCount,
+    categoryBreakdown,
+    recentlyAddedAssets,
+  } = useDashboardStats(assets);
 
   const {
     filters,
@@ -70,6 +83,18 @@ const DashboardPage = () => {
             onCancel={() => setShowForm(false)}
           />
         )}
+
+        <DashboardSummaryCards
+          totalAssets={totalAssets}
+          availableCount={availableCount}
+          assignedCount={assignedCount}
+          maintenanceCount={maintenanceCount}
+        />
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+          <CategoryBreakdown categories={categoryBreakdown} />
+          <RecentlyAddedAssets assets={recentlyAddedAssets} />
+        </div>
 
         <AssetFilter
           filters={filters}

--- a/frontend/src/types/asset.types.ts
+++ b/frontend/src/types/asset.types.ts
@@ -5,6 +5,8 @@ export interface Asset {
   category: string;
   status: string;
   location?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface NewAsset {
@@ -12,4 +14,7 @@ export interface NewAsset {
   serialNumber: string;
   category: string;
   status: string;
+  location?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
Adds dashboard cards for asset statistics.

## Changes
- Shows total asset count
- Shows available, assigned and maintenance counts
- Adds category breakdown
- Adds recently added assets section