### PR TITLE
fix: require authentication on employee and asset history endpoints

### DIFF
--- a/backend/src/asset-history/asset-history.controller.spec.ts
+++ b/backend/src/asset-history/asset-history.controller.spec.ts
@@ -1,0 +1,107 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AssetHistoryController } from './asset-history.controller';
+import { AssetHistoryService } from './asset-history.service';
+import { AssetHistory } from './schemas/asset-history.schema';
+import { JwtStrategy } from '../auth/jwt.strategy';
+import { RolesGuard } from '../auth/roles.guard';
+
+const TEST_SECRET = 'asset-history-controller-spec-secret';
+
+/**
+ * Regression tests for the asset history endpoint, which served the full audit
+ * trail of any asset to unauthenticated callers.
+ */
+describe('AssetHistoryController (authorization)', () => {
+  let app: INestApplication<App>;
+  let jwtService: JwtService;
+
+  const exec = jest.fn();
+  const sort = jest.fn(() => ({ exec }));
+  const assetHistoryModel = {
+    find: jest.fn(() => ({ sort })),
+  };
+
+  const tokenFor = (role: string) =>
+    jwtService.sign({ sub: role, username: role, role });
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = TEST_SECRET;
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        PassportModule,
+        JwtModule.register({
+          secret: TEST_SECRET,
+          signOptions: { expiresIn: '1h' },
+        }),
+      ],
+      controllers: [AssetHistoryController],
+      providers: [
+        AssetHistoryService,
+        JwtStrategy,
+        RolesGuard,
+        {
+          provide: getModelToken(AssetHistory.name),
+          useValue: assetHistoryModel,
+        },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    jwtService = moduleRef.get(JwtService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    exec.mockResolvedValue([]);
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    await request(app.getHttpServer()).get('/asset-history/abc123').expect(401);
+
+    expect(assetHistoryModel.find).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request carrying a token signed with another secret', async () => {
+    const forged = new JwtService({ secret: 'not-the-real-secret' }).sign({
+      sub: 'admin',
+      username: 'admin',
+      role: 'admin',
+    });
+
+    await request(app.getHttpServer())
+      .get('/asset-history/abc123')
+      .set('Authorization', `Bearer ${forged}`)
+      .expect(401);
+
+    expect(assetHistoryModel.find).not.toHaveBeenCalled();
+  });
+
+  it.each(['admin', 'manager', 'viewer'])(
+    'allows %s to read the history of an asset',
+    async (role) => {
+      await request(app.getHttpServer())
+        .get('/asset-history/abc123')
+        .set('Authorization', `Bearer ${tokenFor(role)}`)
+        .expect(200);
+
+      expect(assetHistoryModel.find).toHaveBeenCalledWith({
+        assetId: 'abc123',
+      });
+    },
+  );
+});

--- a/backend/src/asset-history/asset-history.controller.ts
+++ b/backend/src/asset-history/asset-history.controller.ts
@@ -1,10 +1,15 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { AssetHistoryService } from './asset-history.service';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
 
+@UseGuards(AuthGuard('jwt'), RolesGuard)
 @Controller('asset-history')
 export class AssetHistoryController {
   constructor(private readonly assetHistoryService: AssetHistoryService) {}
 
+  @Roles('admin', 'manager', 'viewer')
   @Get(':assetId')
   findByAssetId(@Param('assetId') assetId: string) {
     return this.assetHistoryService.findByAssetId(assetId);

--- a/backend/src/auth/roles.guard.spec.ts
+++ b/backend/src/auth/roles.guard.spec.ts
@@ -1,0 +1,71 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { ROLES_KEY } from './roles.decorator';
+
+interface RequestUser {
+  role?: string;
+}
+
+const createContext = (user: RequestUser | undefined): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+    getHandler: () => undefined,
+    getClass: () => undefined,
+  }) as unknown as ExecutionContext;
+
+describe('RolesGuard', () => {
+  let reflector: Reflector;
+  let guard: RolesGuard;
+
+  const requireRoles = (roles: string[] | undefined) => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key) => {
+      return key === ROLES_KEY ? roles : undefined;
+    });
+  };
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('allows a handler that declares no required roles', () => {
+    requireRoles(undefined);
+
+    expect(guard.canActivate(createContext({ role: 'viewer' }))).toBe(true);
+  });
+
+  it('allows a user whose role is in the required list', () => {
+    requireRoles(['admin', 'manager']);
+
+    expect(guard.canActivate(createContext({ role: 'manager' }))).toBe(true);
+  });
+
+  it('rejects a user whose role is not in the required list', () => {
+    requireRoles(['admin']);
+
+    expect(() => guard.canActivate(createContext({ role: 'viewer' }))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  // Regression: the guard must not fall through to "allowed" when the request
+  // carries no authenticated user at all.
+  it('rejects a request with no user attached', () => {
+    requireRoles(['admin']);
+
+    expect(() => guard.canActivate(createContext(undefined))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('rejects a user object that carries no role', () => {
+    requireRoles(['admin']);
+
+    expect(() => guard.canActivate(createContext({}))).toThrow(
+      ForbiddenException,
+    );
+  });
+});

--- a/backend/src/employees/dto/create-employee.dto.ts
+++ b/backend/src/employees/dto/create-employee.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsNotEmpty, IsOptional, IsEmail } from 'class-validator';
+
+export class CreateEmployeeDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsEmail()
+  @IsOptional()
+  email?: string;
+
+  @IsString()
+  @IsOptional()
+  position?: string;
+
+  @IsString()
+  @IsOptional()
+  department?: string;
+}

--- a/backend/src/employees/employees.controller.spec.ts
+++ b/backend/src/employees/employees.controller.spec.ts
@@ -1,0 +1,163 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { EmployeesController } from './employees.controller';
+import { EmployeesService } from './employees.service';
+import { Employee } from './schemas/employee.schema';
+import { JwtStrategy } from '../auth/jwt.strategy';
+import { RolesGuard } from '../auth/roles.guard';
+
+const TEST_SECRET = 'employees-controller-spec-secret';
+
+/**
+ * Regression tests for the employee endpoints, which were reachable without any
+ * authentication: `GET /employees` exposed the full staff list (name, e-mail,
+ * position, department) and `POST /employees` accepted writes from anyone.
+ * Access was only gated in the frontend router.
+ */
+describe('EmployeesController (authorization)', () => {
+  let app: INestApplication<App>;
+  let jwtService: JwtService;
+
+  const employeeModel = {
+    create: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const tokenFor = (role: string) =>
+    jwtService.sign({ sub: role, username: role, role });
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = TEST_SECRET;
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        PassportModule,
+        JwtModule.register({
+          secret: TEST_SECRET,
+          signOptions: { expiresIn: '1h' },
+        }),
+      ],
+      controllers: [EmployeesController],
+      providers: [
+        EmployeesService,
+        JwtStrategy,
+        RolesGuard,
+        { provide: getModelToken(Employee.name), useValue: employeeModel },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    // Mirrors the global pipe configured in main.ts.
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    jwtService = moduleRef.get(JwtService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    employeeModel.find.mockResolvedValue([]);
+    employeeModel.create.mockResolvedValue({ _id: 'e1', name: 'Test Person' });
+  });
+
+  describe('GET /employees', () => {
+    it('rejects an unauthenticated request', async () => {
+      await request(app.getHttpServer()).get('/employees').expect(401);
+
+      expect(employeeModel.find).not.toHaveBeenCalled();
+    });
+
+    it('rejects a request carrying a token signed with another secret', async () => {
+      const forged = new JwtService({ secret: 'not-the-real-secret' }).sign({
+        sub: 'admin',
+        username: 'admin',
+        role: 'admin',
+      });
+
+      await request(app.getHttpServer())
+        .get('/employees')
+        .set('Authorization', `Bearer ${forged}`)
+        .expect(401);
+
+      expect(employeeModel.find).not.toHaveBeenCalled();
+    });
+
+    it.each(['admin', 'manager', 'viewer'])(
+      'allows %s to read the employee list',
+      async (role) => {
+        await request(app.getHttpServer())
+          .get('/employees')
+          .set('Authorization', `Bearer ${tokenFor(role)}`)
+          .expect(200);
+
+        expect(employeeModel.find).toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('POST /employees', () => {
+    const payload = { name: 'Test Person', department: 'IT' };
+
+    it('rejects an unauthenticated request', async () => {
+      await request(app.getHttpServer())
+        .post('/employees')
+        .send(payload)
+        .expect(401);
+
+      expect(employeeModel.create).not.toHaveBeenCalled();
+    });
+
+    it.each(['manager', 'viewer'])('rejects %s with 403', async (role) => {
+      await request(app.getHttpServer())
+        .post('/employees')
+        .set('Authorization', `Bearer ${tokenFor(role)}`)
+        .send(payload)
+        .expect(403);
+
+      expect(employeeModel.create).not.toHaveBeenCalled();
+    });
+
+    it('allows admin to create an employee', async () => {
+      await request(app.getHttpServer())
+        .post('/employees')
+        .set('Authorization', `Bearer ${tokenFor('admin')}`)
+        .send(payload)
+        .expect(201);
+
+      expect(employeeModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Test Person' }),
+      );
+    });
+
+    it('rejects a payload without a name', async () => {
+      await request(app.getHttpServer())
+        .post('/employees')
+        .set('Authorization', `Bearer ${tokenFor('admin')}`)
+        .send({ department: 'IT' })
+        .expect(400);
+
+      expect(employeeModel.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed e-mail address', async () => {
+      await request(app.getHttpServer())
+        .post('/employees')
+        .set('Authorization', `Bearer ${tokenFor('admin')}`)
+        .send({ name: 'Test Person', email: 'not-an-email' })
+        .expect(400);
+
+      expect(employeeModel.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/employees/employees.controller.ts
+++ b/backend/src/employees/employees.controller.ts
@@ -1,15 +1,22 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { EmployeesService } from './employees.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
 
+@UseGuards(AuthGuard('jwt'), RolesGuard)
 @Controller('employees')
 export class EmployeesController {
   constructor(private readonly employeesService: EmployeesService) {}
 
+  @Roles('admin')
   @Post()
-  async create(@Body() body: any) {
-    return this.employeesService.create(body);
+  async create(@Body() dto: CreateEmployeeDto) {
+    return this.employeesService.create(dto);
   }
 
+  @Roles('admin', 'manager', 'viewer')
   @Get()
   findAll() {
     return this.employeesService.findAll();


### PR DESCRIPTION
Both controllers were mounted without any guard, so GET /employees served the full staff list (name, e-mail, position, department) to anonymous callers, POST /employees accepted writes from anyone, and GET /asset-history/:assetId exposed the audit trail of any asset. Access was only gated in the frontend router, which is not an authorization boundary.

Apply the same guard pattern AssetsController already uses. Read access stays open to every authenticated role because the assets page resolves assignee names and the history modal is reachable by all roles; creating an employee is restricted to admin, matching the admin-only Employees page.

Replace the untyped `@Body() body: any` on the create handler with a CreateEmployeeDto so the global ValidationPipe applies to it.

Tests: 21 specs covering the RolesGuard decision logic and the HTTP behaviour of both controllers. Verified they fail against the previous code: removing the guards turns exactly the 7 rejection assertions red.