### PR TITLE
fix: fail fast on a missing JWT secret and validate update payloads

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
+        "@nestjs/mapped-types": "^2.1.1",
         "@nestjs/mongoose": "^11.0.4",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
@@ -2401,6 +2402,26 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/mongoose": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
+    "@nestjs/mapped-types": "^2.1.1",
     "@nestjs/mongoose": "^11.0.4",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",

--- a/backend/src/assets/assets.controller.spec.ts
+++ b/backend/src/assets/assets.controller.spec.ts
@@ -1,0 +1,189 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AssetsController } from './assets.controller';
+import { AssetsService } from './assets.service';
+import { JwtStrategy } from '../auth/jwt.strategy';
+import { RolesGuard } from '../auth/roles.guard';
+
+const TEST_SECRET = 'assets-controller-spec-secret';
+
+/**
+ * Regression tests for asset request validation.
+ *
+ * The update handler used to declare its body as `Partial<CreateAssetDto>`,
+ * which erases to `Object` at runtime, so the global ValidationPipe skipped it
+ * entirely: unknown fields and raw MongoDB update operators reached
+ * `findByIdAndUpdate` untouched.
+ */
+describe('AssetsController (request validation)', () => {
+  let app: INestApplication<App>;
+  let jwtService: JwtService;
+
+  const assetsService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const tokenFor = (role: string) =>
+    jwtService.sign({ sub: role, username: role, role });
+
+  const patch = (body: unknown, role = 'admin') =>
+    request(app.getHttpServer())
+      .patch('/assets/abc123')
+      .set('Authorization', `Bearer ${tokenFor(role)}`)
+      .send(body as object);
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = TEST_SECRET;
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        PassportModule,
+        JwtModule.register({
+          secret: TEST_SECRET,
+          signOptions: { expiresIn: '1h' },
+        }),
+      ],
+      controllers: [AssetsController],
+      providers: [
+        JwtStrategy,
+        RolesGuard,
+        { provide: AssetsService, useValue: assetsService },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    // Mirrors the global pipe configured in main.ts.
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+    );
+    await app.init();
+
+    jwtService = moduleRef.get(JwtService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assetsService.update.mockResolvedValue({ _id: 'abc123' });
+    assetsService.create.mockResolvedValue({ _id: 'abc123' });
+  });
+
+  describe('PATCH /assets/:id', () => {
+    it('accepts a valid partial update and forwards only those fields', async () => {
+      await patch({ status: 'maintenance', department: 'IT' }).expect(200);
+
+      expect(assetsService.update).toHaveBeenCalledWith('abc123', {
+        status: 'maintenance',
+        department: 'IT',
+      });
+    });
+
+    it('rejects a body containing an unknown field', async () => {
+      await patch({ status: 'available', isAdmin: true }).expect(400);
+
+      expect(assetsService.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a body containing a MongoDB update operator', async () => {
+      await patch({ $unset: { serialNumber: 1 } }).expect(400);
+
+      expect(assetsService.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a field of the wrong type', async () => {
+      await patch({ status: 42 }).expect(400);
+
+      expect(assetsService.update).not.toHaveBeenCalled();
+    });
+
+    it('accepts an empty body without touching unrelated fields', async () => {
+      await patch({}).expect(200);
+
+      expect(assetsService.update).toHaveBeenCalledWith('abc123', {});
+    });
+
+    // The edit form sends an empty string when the date input is cleared, and
+    // Mongoose casts that to null. Validation must not turn clearing a date
+    // into a 400.
+    it('accepts an empty assignedAt as "clear the date"', async () => {
+      await patch({ assignedAt: '' }).expect(200);
+
+      expect(assetsService.update).toHaveBeenCalledWith('abc123', {
+        assignedAt: '',
+      });
+    });
+
+    it('accepts a valid assignedAt', async () => {
+      await patch({ assignedAt: '2026-01-10' }).expect(200);
+
+      expect(assetsService.update).toHaveBeenCalledWith('abc123', {
+        assignedAt: '2026-01-10',
+      });
+    });
+
+    it('rejects an assignedAt that is neither empty nor a date', async () => {
+      await patch({ assignedAt: 'not-a-date' }).expect(400);
+
+      expect(assetsService.update).not.toHaveBeenCalled();
+    });
+
+    it('still enforces the role gate', async () => {
+      await patch({ status: 'available' }, 'viewer').expect(403);
+
+      expect(assetsService.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /assets', () => {
+    const validAsset = {
+      name: 'Dell Latitude 5420',
+      serialNumber: 'DL-2024-001',
+      category: 'Laptop',
+    };
+
+    it('rejects a body containing an unknown field', async () => {
+      await request(app.getHttpServer())
+        .post('/assets')
+        .set('Authorization', `Bearer ${tokenFor('admin')}`)
+        .send({ ...validAsset, unexpected: 'value' })
+        .expect(400);
+
+      expect(assetsService.create).not.toHaveBeenCalled();
+    });
+
+    // Pre-existing bug: the create form always sends assignedAt, so submitting
+    // it with a blank date field was rejected with 400 before this DTO change.
+    it('accepts an asset submitted with a blank date field', async () => {
+      await request(app.getHttpServer())
+        .post('/assets')
+        .set('Authorization', `Bearer ${tokenFor('admin')}`)
+        .send({ ...validAsset, assignedAt: '', department: '' })
+        .expect(201);
+
+      expect(assetsService.create).toHaveBeenCalled();
+    });
+
+    it('accepts a valid asset', async () => {
+      await request(app.getHttpServer())
+        .post('/assets')
+        .set('Authorization', `Bearer ${tokenFor('admin')}`)
+        .send(validAsset)
+        .expect(201);
+
+      expect(assetsService.create).toHaveBeenCalledWith(validAsset);
+    });
+  });
+});

--- a/backend/src/assets/assets.controller.ts
+++ b/backend/src/assets/assets.controller.ts
@@ -13,6 +13,7 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { AssetsService } from './assets.service';
 import { CreateAssetDto } from './dto/create-asset.dto';
+import { UpdateAssetDto } from './dto/update-asset.dto';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 
@@ -26,14 +27,13 @@ export class AssetsController {
   create(@Body() dto: CreateAssetDto) {
     return this.assetsService.create(dto);
   }
-  
+
   @Roles('admin', 'manager', 'viewer')
   @Get()
   findAll() {
     return this.assetsService.findAll();
   }
 
-  
   @Roles('admin', 'manager', 'viewer')
   @Get(':id')
   findOne(@Param('id') id: string) {
@@ -42,11 +42,10 @@ export class AssetsController {
 
   @Roles('admin', 'manager')
   @Patch(':id')
-  update(@Param('id') id: string, @Body() data: Partial<CreateAssetDto>) {
-    return this.assetsService.update(id, data);
+  update(@Param('id') id: string, @Body() dto: UpdateAssetDto) {
+    return this.assetsService.update(id, dto);
   }
 
-  
   @Roles('admin')
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/backend/src/assets/assets.service.ts
+++ b/backend/src/assets/assets.service.ts
@@ -7,6 +7,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Asset, AssetDocument } from './schemas/asset.schema';
 import { CreateAssetDto } from './dto/create-asset.dto';
+import { UpdateAssetDto } from './dto/update-asset.dto';
 import { AssetHistoryService } from '../asset-history/asset-history.service';
 
 @Injectable()
@@ -41,7 +42,7 @@ export class AssetsService {
     return asset;
   }
 
-  async update(id: string, data: Partial<CreateAssetDto>): Promise<Asset> {
+  async update(id: string, data: UpdateAssetDto): Promise<Asset> {
     const oldAsset = await this.assetModel.findById(id).exec();
 
     if (!oldAsset) {

--- a/backend/src/assets/dto/create-asset.dto.ts
+++ b/backend/src/assets/dto/create-asset.dto.ts
@@ -3,6 +3,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsDateString,
+  ValidateIf,
 } from 'class-validator';
 
 export class CreateAssetDto {
@@ -34,7 +35,11 @@ export class CreateAssetDto {
   @IsOptional()
   department?: string;
 
+  // The asset form submits an empty string when the date input is left blank or
+  // cleared, and Mongoose casts that to null. Keep accepting it as "no date"
+  // instead of rejecting the request.
+  @ValidateIf((dto: CreateAssetDto) => dto.assignedAt !== '')
   @IsDateString()
   @IsOptional()
-  assignedAt?: Date;
+  assignedAt?: string;
 }

--- a/backend/src/assets/dto/update-asset.dto.ts
+++ b/backend/src/assets/dto/update-asset.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAssetDto } from './create-asset.dto';
+
+/**
+ * Explicit class so the update payload keeps its validation metadata at
+ * runtime. `Partial<CreateAssetDto>` erases to `Object`, which makes the
+ * global ValidationPipe skip the body entirely.
+ */
+export class UpdateAssetDto extends PartialType(CreateAssetDto) {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -6,14 +6,15 @@ import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './jwt.strategy';
 import { RolesGuard } from './roles.guard';
+import { getJwtSecret } from './jwt-secret';
 
 @Module({
   imports: [
     PassportModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
-      useFactory: async (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
+      useFactory: (configService: ConfigService) => ({
+        secret: getJwtSecret(configService),
         signOptions: { expiresIn: '1h' },
       }),
       inject: [ConfigService],

--- a/backend/src/auth/jwt-secret.spec.ts
+++ b/backend/src/auth/jwt-secret.spec.ts
@@ -1,0 +1,24 @@
+import { ConfigService } from '@nestjs/config';
+import { getJwtSecret } from './jwt-secret';
+
+const configWith = (value: unknown) =>
+  ({ get: () => value }) as unknown as ConfigService;
+
+/**
+ * Regression: JwtStrategy used to fall back to the literal 'fallback-secret'
+ * when JWT_SECRET was unset, so anyone reading the repository could mint a
+ * valid admin token against such a deployment. A missing secret must stop the
+ * application instead.
+ */
+describe('getJwtSecret', () => {
+  it('returns the configured secret', () => {
+    expect(getJwtSecret(configWith('a-real-secret'))).toBe('a-real-secret');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['an empty string', ''],
+  ])('throws when the secret is %s', (_label, value) => {
+    expect(() => getJwtSecret(configWith(value))).toThrow(/JWT_SECRET/);
+  });
+});

--- a/backend/src/auth/jwt-secret.ts
+++ b/backend/src/auth/jwt-secret.ts
@@ -1,0 +1,20 @@
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Reads JWT_SECRET and fails fast when it is missing.
+ *
+ * Both the signing module and the verification strategy go through here, so
+ * they can never end up using different keys, and neither can silently fall
+ * back to a value committed to the repository.
+ */
+export const getJwtSecret = (configService: ConfigService): string => {
+  const secret = configService.get<string>('JWT_SECRET');
+
+  if (!secret) {
+    throw new Error(
+      'JWT_SECRET is not set. Refusing to start: without it, tokens would be signed and verified with a known key.',
+    );
+  }
+
+  return secret;
+};

--- a/backend/src/auth/jwt.strategy.spec.ts
+++ b/backend/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,26 @@
+import { ConfigService } from '@nestjs/config';
+import { JwtStrategy } from './jwt.strategy';
+
+const configWith = (value: unknown) =>
+  ({ get: () => value }) as unknown as ConfigService;
+
+describe('JwtStrategy', () => {
+  // Regression: the strategy used to verify tokens with the literal
+  // 'fallback-secret' when JWT_SECRET was unset, silently accepting tokens
+  // anyone could forge from the public source. It must refuse to exist instead.
+  it('cannot be constructed without a configured secret', () => {
+    expect(() => new JwtStrategy(configWith(undefined))).toThrow(/JWT_SECRET/);
+  });
+
+  it('is constructed when a secret is configured', () => {
+    expect(() => new JwtStrategy(configWith('a-real-secret'))).not.toThrow();
+  });
+
+  it('maps the token payload onto the request user', () => {
+    const strategy = new JwtStrategy(configWith('a-real-secret'));
+
+    expect(
+      strategy.validate({ sub: 'admin', username: 'admin', role: 'admin' }),
+    ).toEqual({ userId: 'admin', username: 'admin', role: 'admin' });
+  });
+});

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { getJwtSecret } from './jwt-secret';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -9,7 +10,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get<string>('JWT_SECRET') || 'fallback-secret',
+      secretOrKey: getJwtSecret(configService),
     });
   }
 

--- a/backend/src/employees/employees.controller.spec.ts
+++ b/backend/src/employees/employees.controller.spec.ts
@@ -55,7 +55,9 @@ describe('EmployeesController (authorization)', () => {
 
     app = moduleRef.createNestApplication();
     // Mirrors the global pipe configured in main.ts.
-    app.useGlobalPipes(new ValidationPipe());
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+    );
     await app.init();
 
     jwtService = moduleRef.get(JwtService);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,7 +4,12 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
   app.enableCors();
   await app.listen(3000, '0.0.0.0');
 }


### PR DESCRIPTION
Two validation gaps from the same review.

JwtStrategy fell back to the literal 'fallback-secret' when JWT_SECRET was unset, so a deployment missing the variable would verify tokens with a key published in this repository. Both the signing module and the strategy now read the secret through getJwtSecret, which throws instead, and they can no longer diverge.

The update handler declared its body as `Partial<CreateAssetDto>`, which erases to `Object` at runtime, so the global ValidationPipe skipped it and unknown fields and raw MongoDB update operators reached findByIdAndUpdate. Introduce UpdateAssetDto and turn on whitelist/forbidNonWhitelisted.

Enabling validation on that path exposed a conflict with the frontend: the asset form submits an empty assignedAt when the date input is blank, which Mongoose casts to null. Rejecting it would have broken clearing a date, so the DTO accepts an empty string explicitly. That also fixes creating an asset with a blank date field, which returned 400 before.

Adds @nestjs/mapped-types for PartialType.

Tests: 39 specs. Verified the new assertions fail against the previous code: restoring the fallback secret, the Partial<> body and the plain ValidationPipe turns exactly the 5 hardening assertions red, and dropping the empty-date rule turns the 2 date assertions red.