### PR TITLE
ci: make AWS deployment manual

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,7 @@ name: Deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+
 
 jobs:
   build-and-push-images:


### PR DESCRIPTION
## Summary

- remove the automatic deployment trigger for pushes to `main`
- keep the deployment workflow available through manual dispatch
- prevent documentation and application changes from triggering an unverified AWS/EKS deployment

## Reason

The previous Terraform remote-state bucket was deleted, and the current AWS infrastructure state has not yet been reconciled. Automatic deployment should remain disabled until the infrastructure redesign is complete.

## Testing

- verified the workflow YAML diff
- no application code changed
- no AWS or Kubernetes commands executed