### PR TITLE
fix: configure frontend backend upstream

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
       - "5173:80"
     environment:
       - VITE_API_URL=${VITE_API_URL:-http://localhost:3000}
+      - BACKEND_UPSTREAM_HOST=backend
     networks:
       - asset-network
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,9 @@ RUN npm run build
 FROM nginx:alpine AS production
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+ENV BACKEND_UPSTREAM_HOST=itassetpulse-backend-service
 
 EXPOSE 80
 

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -6,7 +6,7 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass http://itassetpulse-backend-service:3000/;
+        proxy_pass http://${BACKEND_UPSTREAM_HOST}:3000/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

* make the frontend Nginx backend upstream configurable at container startup
* use the Docker Compose service name for local frontend-to-backend communication
* preserve the existing Kubernetes backend service name as the image default
* prevent the frontend container from entering a restart loop in the local Docker Compose stack

## Root cause

The frontend Nginx configuration hardcoded the Kubernetes service hostname `itassetpulse-backend-service`.

That hostname is available inside the Kubernetes cluster but cannot be resolved on the Docker Compose network, where the backend service is reachable as `backend`. Nginx therefore failed during startup and the frontend container continuously restarted.

## Changes

* rename `frontend/nginx.conf` to `frontend/nginx.conf.template`
* replace the hardcoded backend hostname with `${BACKEND_UPSTREAM_HOST}`
* use the official Nginx image template processing at container startup
* set `itassetpulse-backend-service` as the Docker image default
* override the upstream hostname with `backend` in Docker Compose

## Verification

* `git diff --check`
* frontend Docker image builds successfully
* `docker compose config` resolves successfully
* Docker Compose stack starts successfully
* frontend container remains running with restart count `0`
* generated Nginx configuration contains `proxy_pass http://backend:3000/`
* `http://localhost:5173` returns HTTP 200
* `http://localhost:5173/api/employees` returns HTTP 200 and matches the direct backend response

## Scope

* no application code changed
* no Terraform or Kubernetes resources changed
* no AWS commands were executed
