### PR TITLE
feat(infra): rebuild Terraform state bootstrap (#172)

### DIFF
--- a/infra/terraform/bootstrap/.terraform.lock.hcl
+++ b/infra/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,30 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:MhideOrA+/8rovaA9BC23G4dDrFNZ0mfrRMNptZBIS0=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/infra/terraform/bootstrap/README.md
+++ b/infra/terraform/bootstrap/README.md
@@ -2,27 +2,116 @@
 
 Creates **only** the Terraform remote-state infrastructure. Spec: §4.1.
 
-> Documentation-only until issue **#172** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
-
-## Responsibility
-
-S3 state bucket (versioning, SSE-S3, public-access block, native lockfile) with `prevent_destroy = true`. Uses
-**local state** and creates nothing else. Persistent guardrails (Budget, SNS, GitHub OIDC) live in the
+This stack uses **local state** and creates nothing else. Every other stack (`account`, `foundation`,
+`data`, `ecs`) uses the S3 backend created here. Persistent guardrails (Budget, SNS, GitHub OIDC) live in the
 `account` stack, not here.
 
-## Planned inputs (environment-agnostic)
+## What it creates
 
-`project_name`, `aws_region`. See `terraform.tfvars.example`.
+- `aws_s3_bucket` for remote state, `force_destroy = false` and `lifecycle { prevent_destroy = true }`.
+- `aws_s3_bucket_versioning` — `Enabled`.
+- `aws_s3_bucket_server_side_encryption_configuration` — SSE-S3 (`AES256`; no KMS).
+- `aws_s3_bucket_public_access_block` — all four settings enabled.
+- `aws_s3_bucket_ownership_controls` — `BucketOwnerEnforced` (ACLs disabled).
 
-## Planned outputs
+No DynamoDB table: remote-state stacks lock with the **S3 native lockfile** (`use_lockfile = true` in their
+`backend.hcl`), which writes a `<key>.tflock` object next to each state key in this same bucket.
 
-`state_bucket_name`, `state_bucket_region`.
+## Inputs / outputs
 
-## Notes
+- Inputs (environment-agnostic): `project_name`, `aws_region`. See `terraform.tfvars.example`.
+- Outputs: `state_bucket_name`, `state_bucket_region`.
 
-Will document the state/lock IAM contract (state object: `GetObject`/`PutObject`; lock object `.tflock`:
-`GetObject`/`PutObject`/`DeleteObject` — no `DeleteObject` on the state object), break-glass deletion, and local
-bootstrap-state recovery/import.
+### Bucket name
+
+Deterministic: `${project_name}-terraform-state-${account_id}` (account id from `aws_caller_identity`, never
+hardcoded). This is a project-stable, strongly collision-resistant convention — but because S3 bucket names
+share a global namespace, creation can still fail if another account already reserved the name.
+
+`project_name` is validated to keep the derived name inside the lowercase S3 naming rules (1–34 chars;
+lowercase letters, digits, hyphens; starts and ends with a letter or digit; not an S3-reserved prefix such as
+`xn--`, `sthree-`, `amzn-s3-demo-`).
+
+## Apply (one-time)
+
+Uses local state — **no `backend.hcl`**.
+
+```bash
+cd infra/terraform/bootstrap
+cp terraform.tfvars.example terraform.tfvars   # then edit (git-ignored)
+terraform init
+terraform plan
+terraform apply
+```
+
+After apply, the other stacks point their `backend.hcl` `bucket` at `state_bucket_name`.
+
+### Back up the local state
+
+After the first successful apply, make an **off-repo, tightly-permissioned backup** of the local
+`terraform.tfstate`. State and backup files must **never** be committed to Git (already covered by
+`.gitignore`).
+
+## State-access IAM contract (documentation only — no IAM resource is created here)
+
+This stack creates no IAM resource. It documents two identities:
+
+### 1. Bootstrap provisioning identity
+
+Runs the bootstrap `apply`. Requires exactly the bucket create/read/configure actions this configuration
+uses (no wildcards):
+
+- `sts:GetCallerIdentity`
+- `s3:CreateBucket`, `s3:GetBucketLocation`
+- `s3:PutBucketVersioning`, `s3:GetBucketVersioning`
+- `s3:PutEncryptionConfiguration`, `s3:GetEncryptionConfiguration`
+- `s3:PutBucketPublicAccessBlock`, `s3:GetBucketPublicAccessBlock`
+- `s3:PutBucketOwnershipControls`, `s3:GetBucketOwnershipControls`
+- `s3:PutBucketTagging`, `s3:GetBucketTagging`
+
+### 2. Downstream backend identity
+
+Any identity that runs a remote-state stack, on the state bucket and its objects:
+
+- `s3:ListBucket` on `arn:aws:s3:::<state-bucket>` (optionally condition-scoped to the relevant key prefixes).
+- On the **state object** `arn:aws:s3:::<state-bucket>/<key>`: `s3:GetObject`, `s3:PutObject`. **No
+  `s3:DeleteObject` on the state object** — state history is preserved; deletion is a deliberate break-glass
+  action.
+- On the **lock object** `arn:aws:s3:::<state-bucket>/<key>.tflock`: `s3:GetObject`, `s3:PutObject`,
+  `s3:DeleteObject`.
+- **No KMS permissions** (encryption is SSE-S3).
+
+## Local bootstrap-state recovery (re-adopt, don't recreate)
+
+The bootstrap state is local and small. If it is lost, **re-adopt** the existing bucket instead of recreating
+it (the stable name would collide). Import is a **state-mutating, AWS-access-requiring** recovery operation:
+
+1. Import the bucket resource:
+   ```bash
+   terraform import aws_s3_bucket.terraform_state <bucket-name>
+   ```
+2. Import all four related bucket-configuration resources:
+   ```bash
+   terraform import aws_s3_bucket_versioning.terraform_state <bucket-name>
+   terraform import aws_s3_bucket_server_side_encryption_configuration.terraform_state <bucket-name>
+   terraform import aws_s3_bucket_public_access_block.terraform_state <bucket-name>
+   terraform import aws_s3_bucket_ownership_controls.terraform_state <bucket-name>
+   ```
+3. After **all** imports, run a full `terraform plan`.
+4. Review every proposed change — default or drift differences can produce changes.
+5. A no-op plan is the desired end state, not an assumed immediate result.
+
+## Break-glass deletion
+
+`prevent_destroy` is a **Terraform-config-level** protection, not an AWS-side deletion lock. Deliberate
+removal is a documented manual procedure:
+
+1. Identify and safely back up every dependent remote state.
+2. Remove `prevent_destroy` in a **separately approved** configuration change.
+3. Review the full `terraform plan`.
+4. Explicitly empty the versioned bucket (all objects and **all versions** — `force_destroy = false` means
+   Terraform will not empty it automatically).
+5. Run a controlled `terraform destroy`.
+6. Document the operation.
 
 Implemented in: **#172**.

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -1,0 +1,62 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Deterministic, project-stable and strongly collision-resistant. The account
+  # id is unique within the partition, but the bucket lives in S3's shared
+  # namespace, so creation can still fail if the name is already taken.
+  state_bucket_name = "${var.project_name}-terraform-state-${data.aws_caller_identity.current.account_id}"
+
+  common_tags = {
+    Project   = var.project_name
+    ManagedBy = "terraform"
+    Purpose   = "terraform-state"
+  }
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = local.state_bucket_name
+
+  # Terraform must never auto-empty the shared state store: force_destroy stays
+  # false, so removing prevent_destroy alone is not enough to delete content
+  # (see the break-glass procedure in README.md).
+  force_destroy = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/infra/terraform/bootstrap/outputs.tf
+++ b/infra/terraform/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "state_bucket_name" {
+  description = "Name of the S3 bucket that holds Terraform remote state."
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "state_bucket_region" {
+  description = "AWS region of the Terraform remote-state bucket."
+  value       = var.aws_region
+}

--- a/infra/terraform/bootstrap/providers.tf
+++ b/infra/terraform/bootstrap/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/bootstrap/terraform.tfvars.example
+++ b/infra/terraform/bootstrap/terraform.tfvars.example
@@ -1,4 +1,4 @@
 # bootstrap — environment-agnostic inputs.
-# Copy to terraform.tfvars (git-ignored) and set real values. Implemented in #172.
+# Copy to terraform.tfvars (git-ignored) and set real values.
 project_name = "itassetpulse"
 aws_region   = "eu-north-1" # example — confirm per spec §16

--- a/infra/terraform/bootstrap/variables.tf
+++ b/infra/terraform/bootstrap/variables.tf
@@ -1,0 +1,31 @@
+variable "project_name" {
+  description = "Project name used to build the deterministic Terraform state bucket name."
+  type        = string
+  default     = "itassetpulse"
+
+  # Keep project_name inside the lowercase S3 general-purpose bucket naming
+  # rules so the derived bucket name "<project_name>-terraform-state-<account_id>"
+  # is always valid. 1-34 chars leaves room for the "-terraform-state-" infix
+  # and the 12-digit account id within the 63-char S3 limit.
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,32}[a-z0-9])?$", var.project_name))
+    error_message = "project_name must be 1-34 characters, lowercase letters, digits and hyphens only, and start and end with a letter or digit."
+  }
+
+  # S3 reserves a few name prefixes; exclude the ones a project_name could
+  # realistically collide with.
+  validation {
+    condition = alltrue([
+      !startswith(var.project_name, "xn--"),
+      !startswith(var.project_name, "sthree-"),
+      !startswith(var.project_name, "amzn-s3-demo-"),
+    ])
+    error_message = "project_name must not start with an S3-reserved prefix (xn--, sthree-, amzn-s3-demo-)."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region where the Terraform remote-state bucket is created."
+  type        = string
+  default     = "eu-north-1"
+}

--- a/infra/terraform/bootstrap/versions.tf
+++ b/infra/terraform/bootstrap/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  # >= 1.10 is required by the remote-state stacks for S3 native lockfile
+  # (use_lockfile). The bootstrap stack itself uses local state, but the whole
+  # repository is kept on a consistent minimum version.
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Rebuild the Terraform remote-state `bootstrap` stack (the previous state bucket was deleted). This is the
first, persistent, one-time layer of the modular infrastructure (milestone #24): it provisions the S3 bucket
that every other remote-state stack (`account`, `foundation`, `data`, `ecs`) uses as its backend. Spec:
`docs/infrastructure-modularization-spec.md` §4.1, §6, §7.1/§7.2, §13.1, §16.

## What changed

New `bootstrap` Terraform configuration and operator documentation, scoped strictly to the remote-state
bucket and its direct security configuration.

### State model
- The `bootstrap` stack uses **local state** (no `backend "s3"`, no `backend.hcl`), because it is the stack
  that creates the backend bucket. Its `terraform.tfstate` stays local and git-ignored.

### Bucket naming
- Deterministic name: `${project_name}-terraform-state-${account_id}` (account id from
  `aws_caller_identity`, never hardcoded). Project-stable and strongly collision-resistant; because S3 bucket
  names share a global namespace, creation can still fail if the name is already reserved by another account.
- `project_name` is validated (1–34 chars; lowercase letters/digits/hyphens; starts and ends with a
  letter/digit; excludes S3-reserved prefixes `xn--`, `sthree-`, `amzn-s3-demo-`).

### Bucket security configuration
- **Versioning** enabled.
- **SSE-S3 / AES256** encryption (no KMS).
- **Public access block** — all four settings enabled.
- **Ownership** — `BucketOwnerEnforced` (ACLs disabled).
- **`force_destroy = false`** and **`lifecycle { prevent_destroy = true }`** — Terraform cannot auto-empty or
  destroy the shared state store.

### Locking
- **No DynamoDB table.** Downstream remote-state stacks lock with the **S3 native lockfile**
  (`use_lockfile = true` in their `backend.hcl`), writing a `<key>.tflock` object next to each state key in
  this bucket.

### Documentation (README)
- **IAM contract** for two identities: the **provisioning identity** (explicit bucket create/read/configure
  actions, no wildcards) and the **downstream backend identity** (`ListBucket`; state object
  `GetObject`/`PutObject` with **no `DeleteObject`**; lock object `GetObject`/`PutObject`/`DeleteObject`; no
  KMS). No IAM resource is created here.
- **Local-state backup** guidance (off-repo, tightly-permissioned; never committed).
- **Import/recovery** procedure (re-adopt the bucket via five imports, then a single full `terraform plan`).
- **Break-glass** deletion (config-level `prevent_destroy` is not an AWS deletion lock; explicit versioned
  emptying required).

## No AWS resources created
This PR creates **no AWS resource**. No `terraform plan`, `apply`, `import`, or `destroy` was run, and no AWS
mutation was performed.

## Quality gates (run without AWS access)
- `terraform fmt -check -diff` — pass
- `terraform init -backend=false` — `hashicorp/aws v6.56.0` installed (`~> 6.0`)
- `terraform validate` — `Success! The configuration is valid.`
- Committed multi-platform `.terraform.lock.hcl` (linux/darwin/windows, amd64/arm64)
- `git diff --check` — clean; scope/secret checks — only `infra/terraform/bootstrap/` changed; no
  `terraform.tfvars` / `terraform.tfstate` / `backend.hcl` / `.terraform/` staged

Closes #172
