### PR TITLE
feat(infra): add persistent account stack (#173)

### DIFF
--- a/infra/terraform/account/.terraform.lock.hcl
+++ b/infra/terraform/account/.terraform.lock.hcl
@@ -1,0 +1,30 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:MhideOrA+/8rovaA9BC23G4dDrFNZ0mfrRMNptZBIS0=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/infra/terraform/account/README.md
+++ b/infra/terraform/account/README.md
@@ -3,23 +3,166 @@
 Persistent account-level guardrails and CI identity that survive demo teardown. Spec: §4.2.
 State key: `itassetpulse/global/account.tfstate`.
 
-> Documentation-only until issue **#173** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
+## What it creates
 
-## Responsibility
+- `aws_budgets_budget` — monthly cost budget (`budget_limit_usd`), `ACTUAL` alerts at 50/80/100%. A delayed
+  cost signal, not a real-time kill switch. No automatic budget actions.
+- `aws_sns_topic` + `aws_sns_topic_policy` — shared topic the budget notifies; the policy scopes
+  `SNS:Publish` to the `budgets.amazonaws.com` service principal, restricted by `aws:SourceAccount` (this
+  account) and `aws:SourceArn` (an account-scoped wildcard budget ARN pattern — see "Budget/SNS dependency
+  order" below for why it is not scoped to the specific budget resource).
+- `aws_sns_topic_subscription` — one `email` subscription to `budget_notification_email`. Requires a
+  one-time manual confirmation (see "SNS email subscription lifecycle" below).
+- `aws_iam_openid_connect_provider` for `token.actions.githubusercontent.com` — created only if
+  `create_oidc_provider = true`; otherwise data-sourced by URL from an existing provider.
+- `aws_iam_role` + `aws_iam_role_policy` — minimal image-publish role assumable via GitHub Actions OIDC,
+  scoped to ECR push on `${project_name}-*` repositories.
 
-AWS Budget (with the SNS resource policy that lets AWS Budgets publish); shared SNS topic + email subscription
-(one-time confirmation); GitHub OIDC provider (data-sourced if one already exists); minimal image-publish IAM
-role scoped to ECR push on the project repositories. A **read-only shared-account preflight** (spec §13.1)
-precedes creation. The AWS account ID is obtained via `aws_caller_identity`, never hardcoded.
+No IAM resource for the state-access contract, no VPC/ECR/Atlas/ECS/ALB resource, no application code, no
+image-publish workflow — all out of scope for this stack.
 
-## Planned inputs (environment-agnostic)
+## Inputs / outputs
 
-`project_name`, `aws_region`, `budget_limit_usd`, `budget_notification_email`, `github_owner`, `github_repo`,
-`github_oidc_subject_claims`, `create_oidc_provider`. See `terraform.tfvars.example`.
+- Inputs: `project_name`, `aws_region`, `budget_limit_usd`, `budget_notification_email` (sensitive),
+  `github_owner`, `github_repo`, `github_branch`, `create_oidc_provider`. See `terraform.tfvars.example`.
+- Outputs: `sns_topic_arn`, `budget_name`, `github_oidc_provider_arn`, `image_publish_role_arn`. None are
+  secret values.
 
-## Planned outputs
+### GitHub OIDC trust scope
 
-`sns_topic_arn`, `budget_name`, `github_oidc_provider_arn`, `image_publish_role_arn`.
+The trust policy's `sub` condition is built from a single, locally composed value —
+`repo:${github_owner}/${github_repo}:ref:refs/heads/${github_branch}` — using `StringEquals` (an exact
+value, not a wildcard pattern). Only workflow runs dispatched against `github_branch` (default `main`) can
+assume the image-publish role; there is no wildcard across GitHub repositories or branches.
+
+## Read-only shared-account preflight (repeat before every apply)
+
+The AWS account is shared. Re-run this immediately before every apply, not just once — state in a shared
+account can change between runs:
+
+```bash
+aws sts get-caller-identity
+aws configure get region
+aws s3api head-bucket --bucket <bootstrap-state-bucket>
+aws iam list-open-id-connect-providers        # check for an existing token.actions.githubusercontent.com provider
+aws iam get-role --role-name itassetpulse-image-publish
+aws sns list-topics
+aws budgets describe-budgets --account-id <account-id>
+aws iam simulate-principal-policy --policy-source-arn <caller-arn> --action-names <required-actions>
+```
+
+**`simulate-principal-policy` is advisory only.** It does not guarantee that a live apply will succeed in a
+shared or AWS-Organizations-governed account: service control policies, permission boundaries, or other
+restrictions may not surface identically in the simulation as they would on an actual API call. The real
+confirmation of whether the stack can be applied comes from the runtime-verification chain below —
+**reviewed saved plan → separate apply approval → apply → AWS CLI read-only verification → no-op plan** —
+not from the preflight simulation.
+
+## Budget/SNS dependency order
+
+Final dependency graph: **SNS topic → SNS topic policy → Budget** (one direction only).
+
+The SNS topic policy's `aws:SourceArn` condition is **not** scoped to the specific
+`aws_budgets_budget.monthly_cost.arn` — doing so would create a Terraform dependency cycle, because the
+Budget also depends on the topic policy (`depends_on`, to guarantee the publish permission exists before
+Budgets is configured to use the topic). Instead, `SourceArn` uses an account-scoped wildcard budget ARN
+pattern built from `aws_partition` + `aws_caller_identity`
+(`arn:<partition>:budgets::<account-id>:budget/*`). This matches any Budgets resource in this account, not
+only the one this stack manages — a deliberate trade-off to avoid the cycle. Combined with the
+`aws:SourceAccount` condition, it still excludes every other AWS account's Budgets resources; the principal
+remains scoped to the `budgets.amazonaws.com` service only.
+
+## SNS email subscription lifecycle
+
+`email` is a Terraform **"partially supported"** SNS subscription protocol (per the `aws_sns_topic_subscription`
+resource documentation): an unconfirmed subscription cannot be deleted or unsubscribed by Terraform.
+Destroying an unconfirmed subscription removes it from Terraform state but **does not** remove it from AWS.
+The `pending_confirmation` attribute reports the confirmation status, and only a **confirmed** subscription
+can later be imported and fully managed (see "Recovery / import" below).
+
+Runtime-verification order after apply:
+
+1. check the subscription's initial `PendingConfirmation` state (`aws sns list-subscriptions-by-topic`);
+2. the operator confirms the subscription via the link in the email AWS sends — a **manual, one-time step**,
+   not automatable through Terraform;
+3. re-check that the subscription now has a confirmed ARN;
+4. only then is the email delivery setup considered complete.
+
+> Alerts published while the email subscription is unconfirmed are not delivered to that email endpoint.
+
+Before destroying this stack, separately verify the subscription's confirmation status — an unconfirmed
+subscription cannot be properly removed by Terraform (see above).
+
+## State-access IAM contract (documentation only — no IAM resource beyond the image-publish role)
+
+Any identity that runs a remote-state stack needs, on the state bucket and its objects, the same S3
+state/lock contract documented in `bootstrap/README.md` (§4.1): `s3:ListBucket`; `s3:GetObject` /
+`s3:PutObject` on the state object (no `s3:DeleteObject`); `s3:GetObject` / `s3:PutObject` /
+`s3:DeleteObject` on the lock object. No KMS permissions (SSE-S3).
+
+## IAM role recreation
+
+Recreating the `image_publish` role (e.g., after an import/recovery or a name change) is **not** guaranteed
+to be free of downstream impact:
+
+> Recreating the role with the same name restores the same ARN format, but AWS assigns a new unique
+> principal ID. Any resource-based policies or trust relationships that referenced the deleted role must be
+> reviewed and, where necessary, updated.
+
+## Recovery / import (remote state lost or corrupted)
+
+The account state lives in S3 (versioned), unlike the bootstrap stack's local state:
+
+1. Preferred: restore a prior **S3 object version** of `itassetpulse/global/account.tfstate`
+   (`aws s3api list-object-versions`, then copy the desired version back onto the current key).
+2. If that is not possible:
+   1. import **all** relevant managed resources first (table below);
+   2. only then run a single, full `terraform plan`;
+   3. review **every** proposed change (default- or drift-related differences can produce changes);
+   4. treat a no-op plan as the desired end state, not an assumed immediate result.
+
+| Resource | Import identifier |
+|---|---|
+| `aws_budgets_budget` | `AccountID:BudgetName` |
+| `aws_sns_topic` | topic ARN |
+| `aws_sns_topic_policy` | topic ARN |
+| `aws_sns_topic_subscription` (confirmed only) | subscription ARN (`<topic-arn>:<subscription-id>`) — an unconfirmed subscription cannot be imported |
+| `aws_iam_openid_connect_provider` (only if this stack created it) | provider ARN |
+| `aws_iam_role` | role name |
+| `aws_iam_role_policy` (inline policy) | `role_name:role_policy_name` |
+
+## Break-glass deletion
+
+Not `prevent_destroy`-protected (unlike the bootstrap state bucket) — every resource here is cheap to
+recreate:
+
+- **Budget** — recreation has no data-loss consequence.
+- **SNS topic** — recreation requires the email subscription to be **reconfirmed** (a new confirmation
+  email is sent) — operational friction, not data loss.
+- **IAM role/policy** — see "IAM role recreation" above; review dependent trust/resource policies after
+  recreation.
+- **GitHub OIDC provider (shared-account risk)** — if this stack created it, another team in the shared
+  account may have started relying on it instead of creating their own. Destroying this stack's provider is
+  **not** Terraform-protected; before destroying, verify (coordinate with the shared account owner) that no
+  other identity or workflow depends on it.
+
+## Remote-state locking verification
+
+No dedicated, parallel test observing the short-lived `.tflock` object is required. The runtime
+verification instead confirms:
+
+- `use_lockfile = true` in `backend.hcl`;
+- a successful remote backend init (`terraform init -backend-config=backend.hcl`);
+- a successful saved plan (`terraform plan -out=tfplan`);
+- the `itassetpulse/global/account.tfstate` state object exists in the bucket after apply;
+- no stale `.tflock` object remains after the operation completes;
+- a no-op plan (`terraform plan -detailed-exitcode`, exit `0`).
+
+## Order
+
+Preflight (repeated before every apply) → `terraform init -backend-config=backend.hcl` →
+`terraform plan -out` → review → separate apply approval → apply. This stack does not depend on
+`foundation`/`data`/`ecs` (spec §6); future modifications (e.g., a `budget_limit_usd` change, a different
+`github_branch`) go through the same persistent state, no special reordering needed.
 
 Implemented in: **#173**.

--- a/infra/terraform/account/backend.tf
+++ b/infra/terraform/account/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  # Partial configuration: real values come from backend.hcl (git-ignored),
+  # supplied via `terraform init -backend-config=backend.hcl`.
+  backend "s3" {}
+}

--- a/infra/terraform/account/budget.tf
+++ b/infra/terraform/account/budget.tf
@@ -1,0 +1,35 @@
+resource "aws_budgets_budget" "monthly_cost" {
+  name         = local.budget_name
+  budget_type  = "COST"
+  limit_amount = tostring(var.budget_limit_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # Ensures the SNS topic policy exists before Budgets is configured to publish
+  # to the topic, avoiding a theoretical publish-before-authorized race.
+  depends_on = [aws_sns_topic_policy.budget_alerts]
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 50
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.budget_alerts.arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.budget_alerts.arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.budget_alerts.arn]
+  }
+}

--- a/infra/terraform/account/iam.tf
+++ b/infra/terraform/account/iam.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [local.github_oidc_subject]
+    }
+  }
+}
+
+resource "aws_iam_role" "image_publish" {
+  name               = "${var.project_name}-image-publish"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+}
+
+data "aws_iam_policy_document" "image_publish_permissions" {
+  statement {
+    sid    = "EcrPushPull"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+      "ecr:DescribeImages",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/${var.project_name}-*",
+    ]
+  }
+
+  statement {
+    sid       = "EcrAuth"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"] # required by the AWS API; not resource-scopable
+  }
+}
+
+resource "aws_iam_role_policy" "image_publish" {
+  name   = "${var.project_name}-image-publish"
+  role   = aws_iam_role.image_publish.id
+  policy = data.aws_iam_policy_document.image_publish_permissions.json
+}

--- a/infra/terraform/account/locals.tf
+++ b/infra/terraform/account/locals.tf
@@ -1,0 +1,35 @@
+locals {
+  common_tags = {
+    Project   = var.project_name
+    ManagedBy = "terraform"
+    Purpose   = "account-guardrails"
+  }
+
+  budget_name = "${var.project_name}-monthly-budget"
+
+  # Account-scoped wildcard budget ARN pattern, not a reference to the specific
+  # budget resource: avoids a dependency cycle between the SNS topic policy and
+  # the budget (see sns.tf / budget.tf).
+  budgets_source_arn = join("", [
+    "arn:",
+    data.aws_partition.current.partition,
+    ":budgets::",
+    data.aws_caller_identity.current.account_id,
+    ":budget/*",
+  ])
+
+  github_oidc_subject = join("", [
+    "repo:",
+    var.github_owner,
+    "/",
+    var.github_repo,
+    ":ref:refs/heads/",
+    var.github_branch,
+  ])
+
+  github_oidc_provider_arn = var.create_oidc_provider ? (
+    aws_iam_openid_connect_provider.github_actions[0].arn
+    ) : (
+    data.aws_iam_openid_connect_provider.github_actions[0].arn
+  )
+}

--- a/infra/terraform/account/main.tf
+++ b/infra/terraform/account/main.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}

--- a/infra/terraform/account/oidc.tf
+++ b/infra/terraform/account/oidc.tf
@@ -1,0 +1,18 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  count = var.create_oidc_provider ? 1 : 0
+
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+
+  # thumbprint_list intentionally omitted: for GitHub (and Auth0/GitLab/Google/
+  # S3-JWKS-hosted issuers), AWS validates the provider's server certificate
+  # against its own trusted root CA library rather than a configured
+  # thumbprint, even if one is supplied (hashicorp/aws provider docs for
+  # aws_iam_openid_connect_provider, verified at implementation time).
+}
+
+data "aws_iam_openid_connect_provider" "github_actions" {
+  count = var.create_oidc_provider ? 0 : 1
+
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/infra/terraform/account/outputs.tf
+++ b/infra/terraform/account/outputs.tf
@@ -1,0 +1,19 @@
+output "sns_topic_arn" {
+  description = "ARN of the SNS topic used for budget alerts."
+  value       = aws_sns_topic.budget_alerts.arn
+}
+
+output "budget_name" {
+  description = "Name of the monthly cost budget."
+  value       = aws_budgets_budget.monthly_cost.name
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider (created by this stack or data-sourced from an existing one)."
+  value       = local.github_oidc_provider_arn
+}
+
+output "image_publish_role_arn" {
+  description = "ARN of the IAM role GitHub Actions assumes via OIDC to push images to ECR."
+  value       = aws_iam_role.image_publish.arn
+}

--- a/infra/terraform/account/providers.tf
+++ b/infra/terraform/account/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/account/sns.tf
+++ b/infra/terraform/account/sns.tf
@@ -1,0 +1,45 @@
+resource "aws_sns_topic" "budget_alerts" {
+  name = "${var.project_name}-budget-alerts"
+}
+
+data "aws_iam_policy_document" "budget_alerts_topic_policy" {
+  statement {
+    sid     = "AllowBudgetsPublish"
+    effect  = "Allow"
+    actions = ["SNS:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["budgets.amazonaws.com"]
+    }
+
+    resources = [aws_sns_topic.budget_alerts.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [local.budgets_source_arn]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "budget_alerts" {
+  arn    = aws_sns_topic.budget_alerts.arn
+  policy = data.aws_iam_policy_document.budget_alerts_topic_policy.json
+}
+
+# email is a Terraform "partially supported" SNS subscription protocol: an
+# unconfirmed subscription cannot be deleted/unsubscribed by Terraform. See
+# README for the required one-time manual confirmation and its destroy-time
+# implications.
+resource "aws_sns_topic_subscription" "budget_alerts_email" {
+  topic_arn = aws_sns_topic.budget_alerts.arn
+  protocol  = "email"
+  endpoint  = var.budget_notification_email
+}

--- a/infra/terraform/account/terraform.tfvars.example
+++ b/infra/terraform/account/terraform.tfvars.example
@@ -1,12 +1,11 @@
 # account — environment-agnostic persistent guardrails.
-# Copy to terraform.tfvars (git-ignored) and set real values. Implemented in #173.
-project_name               = "itassetpulse"
-aws_region                 = "eu-north-1" # example — confirm per spec §16
-budget_limit_usd           = 10
-budget_notification_email  = "you@example.com" # replace
+# Copy to terraform.tfvars (git-ignored) and set real values.
+project_name              = "itassetpulse"
+aws_region                = "eu-north-1" # example — confirm per spec §16
+budget_limit_usd          = 10
+budget_notification_email = "you@example.com" # replace
 github_owner               = "AldrionDev"
 github_repo                = "ITAssetPulse"
-# Finalize the exact subject claim(s) in #173 (branch / tag / environment scope):
-github_oidc_subject_claims = ["repo:AldrionDev/ITAssetPulse:ref:refs/heads/main"]
+github_branch               = "main" # only workflow runs on this branch can assume the image-publish role
 # Set false if the shared account already has the GitHub OIDC provider (preflight §13.1):
-create_oidc_provider       = true
+create_oidc_provider = true

--- a/infra/terraform/account/variables.tf
+++ b/infra/terraform/account/variables.tf
@@ -1,0 +1,59 @@
+variable "project_name" {
+  description = "Project name used to build resource names (Budget, SNS topic, IAM role)."
+  type        = string
+  default     = "itassetpulse"
+
+  # Charset/length only: this stack creates no S3 bucket, so the S3 reserved-prefix
+  # exclusions used by the bootstrap stack's project_name validation do not apply here.
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,32}[a-z0-9])?$", var.project_name))
+    error_message = "project_name must be 1-34 characters, lowercase letters, digits and hyphens only, and start and end with a letter or digit."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region where the account-level guardrails are created."
+  type        = string
+  default     = "eu-north-1"
+}
+
+variable "budget_limit_usd" {
+  description = "Monthly AWS Budget threshold in USD."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.budget_limit_usd > 0
+    error_message = "budget_limit_usd must be greater than 0."
+  }
+}
+
+variable "budget_notification_email" {
+  description = "Email address subscribed to the budget-alerts SNS topic. Requires a one-time manual confirmation (see README)."
+  type        = string
+  sensitive   = true
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user that owns the repository allowed to assume the image-publish role."
+  type        = string
+  default     = "AldrionDev"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name allowed to assume the image-publish role."
+  type        = string
+  default     = "ITAssetPulse"
+}
+
+variable "github_branch" {
+  description = "Branch the GitHub Actions OIDC trust policy is scoped to. Only workflow runs dispatched against this branch can assume the image-publish role."
+  type        = string
+  default     = "main"
+}
+
+variable "create_oidc_provider" {
+  description = "Whether to create the GitHub Actions OIDC provider. Set to false if the shared account already has one for token.actions.githubusercontent.com (verify via the read-only preflight before every apply)."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/account/versions.tf
+++ b/infra/terraform/account/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  # >= 1.10 for the S3 native lockfile (use_lockfile) used by this stack's remote backend.
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Add the `account` Terraform stack: the second, **persistent** layer of the modular infrastructure
(milestone #24) after `bootstrap` (#172). It provisions account/region-scoped guardrails and CI identity
that must survive `apply → demo → destroy` — separate from the ephemeral `foundation`/`data`/`ecs` stacks.
Spec: `docs/infrastructure-modularization-spec.md` §4.2, §6, §7.1/§7.2, §8, §13.1, §16.

## Remote backend

- State key: **`itassetpulse/global/account.tfstate`** (environment-agnostic — no `environment` segment,
  unlike the `demo/*` keys).
- Remote S3 backend on the bucket created by `bootstrap` (#172), with **S3 native lockfile**
  (`use_lockfile = true`) — no DynamoDB table.
- `backend.tf` is a partial `backend "s3" {}` block; the real `backend.hcl` stays local and git-ignored.

## What this stack creates

- **AWS Budget** — monthly cost threshold (`budget_limit_usd`, default 10 USD), **`ACTUAL`** alerts at
  **50/80/100%** (a delayed cost signal, not a real-time kill switch; no automatic budget actions).
- **SNS topic + policy** — the budget notifies via `subscriber_sns_topic_arns`; the topic policy grants
  `SNS:Publish` to the `budgets.amazonaws.com` service principal only, restricted by `aws:SourceAccount`
  (this account) and an account-scoped wildcard `aws:SourceArn` budget-ARN pattern (built from
  `aws_partition` + `aws_caller_identity`, **not** a reference to the specific budget resource — see
  "Budget–SNS dependency order" below).
- **SNS email subscription** — one `email` subscription to `budget_notification_email`
  (`sensitive = true`). Requires a **one-time manual confirmation** via the link AWS emails; `email` is a
  Terraform *"partially supported"* protocol, and an unconfirmed subscription cannot be deleted/unsubscribed
  by Terraform (documented in the stack README, with the exact runtime-verification order: check
  `PendingConfirmation` → operator confirms → re-check confirmed → only then is delivery considered set up).
- **GitHub Actions OIDC provider** — created **conditionally** (`create_oidc_provider`, default `true`);
  when `false`, it is **data-sourced by URL** instead of created, so no duplicate provider is ever attempted
  in the shared account. No `thumbprint_list` (AWS validates GitHub's certificate against its own trusted
  root CA library rather than a configured thumbprint, confirmed via the current `hashicorp/aws` provider
  docs) — no `hashicorp/tls` provider dependency.
- **Minimal image-publish IAM role** — trust policy scoped to a single, locally composed subject
  (`repo:${github_owner}/${github_repo}:ref:refs/heads/${github_branch}`), using **`StringEquals`** (not
  `StringLike`) on both the `aud` and `sub` conditions — an exact value, not a wildcard pattern. Permissions:
  ECR push actions scoped to `arn:...:repository/${project_name}-*` (valid whether or not `foundation`
  (#174) has created the ECR repos yet), plus a **separate** `ecr:GetAuthorizationToken` statement with
  `Resource = "*"` (the only broad-resource statement — required by the AWS API, not scopable). No
  `ecr:BatchGetImage`; `ecr:DescribeImages` is kept and documented (needed by the future #177 publish
  workflow to detect an already-existing immutable image tag before pushing).

## Budget–SNS dependency order

Final graph: **SNS topic → SNS topic policy → Budget** (one direction only). The topic policy's
`SourceArn` condition intentionally does **not** reference `aws_budgets_budget.monthly_cost.arn` — doing so
together with the Budget's `depends_on = [aws_sns_topic_policy...]` would create a Terraform dependency
cycle. Using an account-scoped wildcard budget-ARN pattern instead breaks the cycle while still excluding
every other AWS account's Budgets resources (via `SourceAccount` + the ARN's account segment).

## Read-only preflight — limits

The stack README documents a repeatable, read-only shared-account preflight (caller identity, region,
state-bucket reachability, existing GitHub OIDC provider, name collisions, `simulate-principal-policy`) to
be re-run **immediately before every apply** (shared Codecool account, state can change between runs).
`simulate-principal-policy` is explicitly documented as **advisory only** — it does not guarantee a live
apply will succeed in a shared or AWS-Organizations-governed account. The actual confirmation comes from the
runtime-verification chain: reviewed saved plan → separate apply approval → apply → AWS CLI read-only
verification → no-op plan.

## Recovery / destroy documentation

- No `prevent_destroy` in this stack (every resource here is cheap to recreate, unlike the bootstrap state
  bucket) — each resource's recreation consequence is documented individually (SNS requires re-confirming
  the email subscription; IAM role recreation keeps the same ARN format but gets a new principal ID, so
  dependent trust/resource policies must be reviewed).
- Remote-state recovery (S3, versioned): prefer restoring a prior S3 object version; otherwise import **all**
  relevant resources first, then run one full `terraform plan`, review every change, and treat a no-op plan
  as the desired end state — not an assumed immediate result. The README lists the exact import identifier
  for all seven resources (Budget, SNS topic, SNS topic policy, confirmed SNS subscription, OIDC provider,
  IAM role, inline IAM role policy), verified against the current `hashicorp/aws` provider documentation.
- Break-glass: destroying the shared GitHub OIDC provider (if this stack created it) is a documented,
  procedural shared-account risk, not a Terraform-enforced one — verify no other team depends on it first.

## Quality gates run (no AWS access)

- `terraform fmt -check -diff` — pass
- `terraform init -backend=false` — `hashicorp/aws v6.56.0` installed (`~> 6.0`)
- `terraform validate` — `Success!` (this also gives confidence the Budget–SNS graph has no cycle, since
  graph construction happens during validate without contacting AWS)
- Committed multi-platform `.terraform.lock.hcl`
- `git diff --cached --check` — clean; scope/secret scan — only `infra/terraform/account/` changed; no real
  `terraform.tfvars` / `backend.hcl` / `.tfstate` / `.tflock` / saved plan; no hardcoded AWS account ID
  (verified: only `data.aws_caller_identity.current.account_id` is used)

## Not yet run

**No real-backend `terraform plan` and no AWS apply have been run.** No AWS resource has been created by
this PR. That runtime verification (real `backend.hcl` + `terraform.tfvars`, remote backend init, saved
plan, review, separate apply approval) is a deliberately separate, later step.

Closes #173
