### PR TITLE
feat(infra): add network and ECR foundation (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,32 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+
+  terraform-foundation-validate:
+    name: Terraform foundation validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.10.0"
+          terraform_wrapper: false
+
+      - name: Terraform fmt check (foundation)
+        run: terraform fmt -check -recursive infra/terraform/foundation
+
+      - name: Terraform fmt check (modules/network)
+        run: terraform fmt -check -recursive infra/terraform/modules/network
+
+      - name: Terraform fmt check (modules/ecr-repository)
+        run: terraform fmt -check -recursive infra/terraform/modules/ecr-repository
+
+      - name: Terraform init (foundation, no backend)
+        run: terraform -chdir=infra/terraform/foundation init -backend=false -lockfile=readonly
+
+      - name: Terraform validate (foundation)
+        run: terraform -chdir=infra/terraform/foundation validate

--- a/infra/terraform/foundation/.terraform.lock.hcl
+++ b/infra/terraform/foundation/.terraform.lock.hcl
@@ -1,0 +1,30 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:MhideOrA+/8rovaA9BC23G4dDrFNZ0mfrRMNptZBIS0=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/infra/terraform/foundation/README.md
+++ b/infra/terraform/foundation/README.md
@@ -2,23 +2,38 @@
 
 Platform-agnostic base for compute. Spec: §4.3. State key: `itassetpulse/demo/foundation.tfstate`.
 
-> Documentation-only until issue **#174** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
+## What it creates
 
-## Responsibility
+- `module.network` (once) — VPC, public/private subnets across `availability_zone_count` AZs, Internet
+  Gateway, public and private route tables + associations. **No NAT Gateway in v1.** See
+  `modules/network/README.md`.
+- `module.ecr_backend` / `module.ecr_frontend` (`modules/ecr-repository`, twice) — one ECR repository per
+  application component, named `${project_name}-${environment}-backend` / `-frontend`, `IMMUTABLE` tags,
+  `force_delete = true` for clean ephemeral teardown (spec §10.4). See `modules/ecr-repository/README.md`.
 
-`modules/network` (once) + `modules/ecr-repository` (twice: backend, frontend). Public and private subnets,
-**no NAT Gateway in v1**.
+`foundation` does not depend on any other stack.
 
-## Planned inputs
+## Inputs / outputs
 
-`project_name`, `environment`, `common_tags`, `aws_region`, `vpc_cidr`, `public_subnet_cidrs`,
-`private_subnet_cidrs`, `availability_zone_count`, ECR settings (`scan_on_push`, `lifecycle_keep_count`,
-`force_delete`). Values from `../environments/demo/foundation.tfvars`.
+- Inputs: `project_name`, `environment`, `common_tags`, `aws_region`, `vpc_cidr`, `public_subnet_cidrs`,
+  `private_subnet_cidrs`, `availability_zone_count`, `scan_on_push`, `lifecycle_keep_count`, `force_delete`.
+  See `../environments/demo/foundation.tfvars.example`.
+- Outputs: `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `backend_ecr_repository_url` + `_arn`,
+  `frontend_ecr_repository_url` + `_arn`. No secret values.
 
-## Planned outputs
+## Order
 
-`vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `backend_ecr_repository_url` + `_arn`,
-`frontend_ecr_repository_url` + `_arn`.
+```bash
+cd infra/terraform/foundation
+cp backend.hcl.example backend.hcl                                  # fill in the bootstrap-created bucket
+cp ../environments/demo/foundation.tfvars.example ../environments/demo/foundation.tfvars
+terraform init -backend-config=backend.hcl
+terraform plan  -var-file=../environments/demo/foundation.tfvars -out=tfplan
+terraform apply "tfplan"
+```
+
+Apply/destroy order per spec §13: `bootstrap → account → foundation → data → (publish images) → ecs`.
+Teardown per demo (spec §13.5): `ecs destroy → data destroy → foundation destroy`. `force_delete = true` lets
+`terraform destroy` remove both ECR repositories even if they still contain images.
 
 Implemented in: **#174**.

--- a/infra/terraform/foundation/backend.tf
+++ b/infra/terraform/foundation/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  # Partial configuration: real values come from backend.hcl (git-ignored),
+  # supplied via `terraform init -backend-config=backend.hcl`.
+  backend "s3" {}
+}

--- a/infra/terraform/foundation/ecr.tf
+++ b/infra/terraform/foundation/ecr.tf
@@ -1,0 +1,19 @@
+module "ecr_backend" {
+  source = "../modules/ecr-repository"
+
+  name                 = "${local.name_prefix}-backend"
+  common_tags          = local.common_tags
+  scan_on_push         = var.scan_on_push
+  lifecycle_keep_count = var.lifecycle_keep_count
+  force_delete         = var.force_delete
+}
+
+module "ecr_frontend" {
+  source = "../modules/ecr-repository"
+
+  name                 = "${local.name_prefix}-frontend"
+  common_tags          = local.common_tags
+  scan_on_push         = var.scan_on_push
+  lifecycle_keep_count = var.lifecycle_keep_count
+  force_delete         = var.force_delete
+}

--- a/infra/terraform/foundation/locals.tf
+++ b/infra/terraform/foundation/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = merge(var.common_tags, {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Purpose     = "foundation"
+  })
+}

--- a/infra/terraform/foundation/network.tf
+++ b/infra/terraform/foundation/network.tf
@@ -1,0 +1,12 @@
+module "network" {
+  source = "../modules/network"
+
+  project_name = var.project_name
+  environment  = var.environment
+  common_tags  = local.common_tags
+
+  vpc_cidr                = var.vpc_cidr
+  public_subnet_cidrs     = var.public_subnet_cidrs
+  private_subnet_cidrs    = var.private_subnet_cidrs
+  availability_zone_count = var.availability_zone_count
+}

--- a/infra/terraform/foundation/outputs.tf
+++ b/infra/terraform/foundation/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = module.network.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets, in the same order as the public_subnet_cidrs input."
+  value       = module.network.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets, in the same order as the private_subnet_cidrs input."
+  value       = module.network.private_subnet_ids
+}
+
+output "backend_ecr_repository_url" {
+  description = "URL of the backend ECR repository."
+  value       = module.ecr_backend.repository_url
+}
+
+output "backend_ecr_repository_arn" {
+  description = "ARN of the backend ECR repository."
+  value       = module.ecr_backend.repository_arn
+}
+
+output "frontend_ecr_repository_url" {
+  description = "URL of the frontend ECR repository."
+  value       = module.ecr_frontend.repository_url
+}
+
+output "frontend_ecr_repository_arn" {
+  description = "ARN of the frontend ECR repository."
+  value       = module.ecr_frontend.repository_arn
+}

--- a/infra/terraform/foundation/providers.tf
+++ b/infra/terraform/foundation/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/foundation/variables.tf
+++ b/infra/terraform/foundation/variables.tf
@@ -1,0 +1,80 @@
+variable "project_name" {
+  description = "Project name used to build resource names and tags."
+  type        = string
+  default     = "itassetpulse"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,32}[a-z0-9])?$", var.project_name))
+    error_message = "project_name must be 1-34 characters, lowercase letters, digits and hyphens only, and start and end with a letter or digit."
+  }
+}
+
+variable "environment" {
+  description = "Environment name used to build resource names, tags, and the remote-state key (e.g. \"demo\")."
+  type        = string
+  default     = "demo"
+}
+
+variable "common_tags" {
+  description = "Additional tags merged into every resource created by this stack."
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region where the foundation resources are created."
+  type        = string
+  default     = "eu-north-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for the public subnets, one per availability zone, in AZ order."
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for the private subnets, one per availability zone, in AZ order."
+  type        = list(string)
+}
+
+variable "availability_zone_count" {
+  description = "Number of availability zones to spread the public and private subnets across."
+  type        = number
+
+  validation {
+    condition     = var.availability_zone_count >= 1 && var.availability_zone_count == floor(var.availability_zone_count)
+    error_message = "availability_zone_count must be a whole number greater than or equal to 1."
+  }
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == var.availability_zone_count && length(var.private_subnet_cidrs) == var.availability_zone_count
+    error_message = "public_subnet_cidrs and private_subnet_cidrs must each have exactly availability_zone_count entries."
+  }
+}
+
+variable "scan_on_push" {
+  description = "Whether ECR repositories scan images for vulnerabilities on push."
+  type        = bool
+  default     = true
+}
+
+variable "lifecycle_keep_count" {
+  description = "Number of most recent images each ECR repository retains."
+  type        = number
+
+  validation {
+    condition     = var.lifecycle_keep_count > 0 && var.lifecycle_keep_count == floor(var.lifecycle_keep_count)
+    error_message = "lifecycle_keep_count must be a positive whole number."
+  }
+}
+
+variable "force_delete" {
+  description = "Whether ECR repositories can be deleted by Terraform even if they still contain images (ephemeral teardown)."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/foundation/versions.tf
+++ b/infra/terraform/foundation/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/terraform/modules/ecr-repository/README.md
+++ b/infra/terraform/modules/ecr-repository/README.md
@@ -3,20 +3,19 @@
 A single ECR repository and its lifecycle policy. Instantiated twice by `foundation` (backend, frontend).
 Spec: §5.2.
 
-> Documentation-only until issue **#174** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
+## What it creates
 
-## Responsibility
+- `aws_ecr_repository` — `image_tag_mutability` is fixed to `IMMUTABLE` inside the module (not a caller
+  input); `force_delete = var.force_delete` allows a clean `terraform destroy` even with images still present
+  (spec §10.4, ephemeral teardown); `image_scanning_configuration.scan_on_push = var.scan_on_push`.
+- `aws_ecr_lifecycle_policy` — a single rule expiring images beyond the most recent `lifecycle_keep_count`
+  (`tagStatus = "any"`, `countType = "imageCountMoreThan"`), confirmed against the current AWS ECR lifecycle
+  policy schema.
 
-ECR repository; image scanning; lifecycle policy; tags. **Image tag mutability is fixed to `IMMUTABLE` inside
-the module** (not a caller-selectable input). `force_delete` is supported for ephemeral teardown.
+## Inputs / outputs
 
-## Planned inputs
-
-`name`, `common_tags`, `scan_on_push`, `lifecycle_keep_count`, `force_delete`.
-
-## Planned outputs
-
-`repository_url`, `repository_arn`, `repository_name`.
+- Inputs: `name`, `common_tags`, `scan_on_push`, `lifecycle_keep_count` (must be a positive whole number),
+  `force_delete`.
+- Outputs: `repository_url`, `repository_arn`, `repository_name`.
 
 Implemented in: **#174**.

--- a/infra/terraform/modules/ecr-repository/main.tf
+++ b/infra/terraform/modules/ecr-repository/main.tf
@@ -1,0 +1,32 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = var.force_delete
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep the most recent ${var.lifecycle_keep_count} images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.lifecycle_keep_count
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/ecr-repository/outputs.tf
+++ b/infra/terraform/modules/ecr-repository/outputs.tf
@@ -1,0 +1,14 @@
+output "repository_url" {
+  description = "URL of the repository, used to build image references."
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = "ARN of the repository."
+  value       = aws_ecr_repository.this.arn
+}
+
+output "repository_name" {
+  description = "Name of the repository."
+  value       = aws_ecr_repository.this.name
+}

--- a/infra/terraform/modules/ecr-repository/variables.tf
+++ b/infra/terraform/modules/ecr-repository/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "Name of the ECR repository."
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Tags applied to the repository."
+  type        = map(string)
+  default     = {}
+}
+
+variable "scan_on_push" {
+  description = "Whether to scan images for vulnerabilities on push."
+  type        = bool
+  default     = true
+}
+
+variable "lifecycle_keep_count" {
+  description = "Number of most recent images to retain; older images are expired by the lifecycle policy."
+  type        = number
+
+  validation {
+    condition     = var.lifecycle_keep_count > 0 && var.lifecycle_keep_count == floor(var.lifecycle_keep_count)
+    error_message = "lifecycle_keep_count must be a positive whole number."
+  }
+}
+
+variable "force_delete" {
+  description = "Whether to allow Terraform to delete the repository even if it still contains images (ephemeral teardown)."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/modules/ecr-repository/versions.tf
+++ b/infra/terraform/modules/ecr-repository/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/terraform/modules/network/README.md
+++ b/infra/terraform/modules/network/README.md
@@ -2,22 +2,29 @@
 
 VPC networking for the ITAssetPulse stacks. Instantiated once by `foundation`. Spec: §5.1.
 
-> Documentation-only until issue **#174** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
+## What it creates
 
-## Responsibility
+- `aws_vpc` — `enable_dns_support` / `enable_dns_hostnames` enabled (required for private DNS resolution of
+  AWS service endpoints such as ECR and CloudWatch Logs from the public subnets).
+- `aws_internet_gateway`, attached to the VPC.
+- `aws_subnet` (public) — one per entry in `public_subnet_cidrs`, `map_public_ip_on_launch = true`, spread
+  across `availability_zone_count` AZs via `data "aws_availability_zones"`.
+- `aws_subnet` (private) — one per entry in `private_subnet_cidrs`, same AZ spread, no public IP assignment.
+- `aws_route_table` (public) with a `0.0.0.0/0 → aws_internet_gateway` route, plus associations for every
+  public subnet.
+- `aws_route_table` (private) with **no default route** — local-only — plus associations for every private
+  subnet. It exists purely as the stable attachment point for a future NAT Gateway route; adding NAT later is
+  a route addition, not a module restructure.
 
-VPC; public and private subnets across multiple AZs; Internet Gateway; public and private route tables and
-associations; tags. **No NAT Gateway, Elastic IP, or VPC endpoints in v1, and no `enable_nat_*` toggle** (NAT is
-added in a dedicated later change when private-subnet compute is actually built).
+**No NAT Gateway, Elastic IP, or VPC endpoint in v1, and no `enable_nat_*` toggle** (NAT is added in a
+dedicated later change when private-subnet compute is actually built).
 
-## Planned inputs
+## Inputs / outputs
 
-`project_name`, `environment`, `common_tags`, `vpc_cidr`, `public_subnet_cidrs`, `private_subnet_cidrs`,
-`availability_zone_count`.
-
-## Planned outputs
-
-`vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `vpc_cidr` (route table IDs only if a consumer needs them).
+- Inputs: `project_name`, `environment`, `common_tags`, `vpc_cidr`, `public_subnet_cidrs`,
+  `private_subnet_cidrs`, `availability_zone_count`. `public_subnet_cidrs` and `private_subnet_cidrs` must each
+  have exactly `availability_zone_count` entries (enforced via variable validation).
+- Outputs: `vpc_id`, `vpc_cidr`, `public_subnet_ids`, `private_subnet_ids`. Subnet ID lists preserve the order
+  of the corresponding input CIDR lists, so callers can reference them positionally and stably.
 
 Implemented in: **#174**.

--- a/infra/terraform/modules/network/main.tf
+++ b/infra/terraform/modules/network/main.tf
@@ -1,0 +1,89 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, var.availability_zone_count)
+  name_prefix        = "${var.project_name}-${var.environment}"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.common_tags, {
+    Name = "${local.name_prefix}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.common_tags, {
+    Name = "${local.name_prefix}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = local.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.common_tags, {
+    Name = "${local.name_prefix}-public-${count.index}"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = local.availability_zones[count.index]
+
+  tags = merge(var.common_tags, {
+    Name = "${local.name_prefix}-private-${count.index}"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${local.name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# No default route: v1 has no NAT Gateway. This table exists as the stable
+# association point for private subnets so a later NAT milestone only needs
+# to add a route, not restructure the module (spec §5.1).
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.common_tags, {
+    Name = "${local.name_prefix}-private-rt"
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/terraform/modules/network/outputs.tf
+++ b/infra/terraform/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "CIDR block of the VPC."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets, in the same order as public_subnet_cidrs."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets, in the same order as private_subnet_cidrs."
+  value       = aws_subnet.private[*].id
+}

--- a/infra/terraform/modules/network/variables.tf
+++ b/infra/terraform/modules/network/variables.tf
@@ -1,0 +1,50 @@
+variable "project_name" {
+  description = "Project name used to build resource names and tags."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used to build resource names and tags (e.g. \"demo\")."
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Tags applied to every resource created by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for the public subnets, one per availability zone, in AZ order."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == length(var.private_subnet_cidrs)
+    error_message = "public_subnet_cidrs and private_subnet_cidrs must have the same length."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for the private subnets, one per availability zone, in AZ order."
+  type        = list(string)
+}
+
+variable "availability_zone_count" {
+  description = "Number of availability zones to spread the public and private subnets across."
+  type        = number
+
+  validation {
+    condition     = var.availability_zone_count >= 1 && var.availability_zone_count == floor(var.availability_zone_count)
+    error_message = "availability_zone_count must be a whole number greater than or equal to 1."
+  }
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == var.availability_zone_count
+    error_message = "public_subnet_cidrs and private_subnet_cidrs must each have exactly availability_zone_count entries."
+  }
+}

--- a/infra/terraform/modules/network/versions.tf
+++ b/infra/terraform/modules/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `modules/network`: VPC, public and private subnets across `availability_zone_count` availability zones, an Internet Gateway, and public/private route tables + associations. No NAT Gateway, Elastic IP, or VPC endpoint is created in v1, and there is no `enable_nat_*` toggle — the private route table exists with no default route purely as the stable attachment point for a later NAT milestone.
- Adds `modules/ecr-repository`: one ECR repository per call, `image_tag_mutability` fixed to `IMMUTABLE` inside the module, `image_scanning_configuration.scan_on_push` configurable, and an `aws_ecr_lifecycle_policy` that expires images beyond the most recent `lifecycle_keep_count`. `force_delete` is exposed so `terraform destroy` can remove a non-empty repository during ephemeral teardown.
- Adds the `foundation` root stack: `module.network` once, `module.ecr_backend` / `module.ecr_frontend` twice (explicit blocks, not `for_each`), S3 partial-backend config (`itassetpulse/demo/foundation.tfstate`), and outputs `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `backend_ecr_repository_url` + `_arn`, `frontend_ecr_repository_url` + `_arn`. No secret values are output. The foundation stack has no Terraform data dependency on another stack. Its S3 backend operationally uses the remote-state bucket created by the bootstrap stack.
- Commits `infra/terraform/foundation/.terraform.lock.hcl`, generated against `hashicorp/aws ~> 6.0` (resolved to 6.56.0) with the same platform coverage (`linux_amd64`, `linux_arm64`, `darwin_amd64`, `darwin_arm64`, `windows_amd64`) as the existing `bootstrap`/`account` lock files.
- Adds a `terraform-foundation-validate` CI job (`.github/workflows/ci.yml`) that runs, with no AWS credentials: `terraform fmt -check -recursive` separately for `foundation`, `modules/network`, and `modules/ecr-repository`, then `terraform init -backend=false -lockfile=readonly` and `terraform validate` for `foundation`. This job is scoped to `foundation` only; generalizing CI validation to every stack is deliberately left to #176.

## AWS-free quality gates run

- `terraform fmt -check -recursive` for `foundation`, `modules/network`, `modules/ecr-repository` — all pass
- `terraform init -backend=false -lockfile=readonly` + `terraform validate` for `foundation` — succeeds
- `git diff --check` — no whitespace errors
- `git status` — only `.tf` / `README.md` / `.terraform.lock.hcl` are tracked; `.tfvars`, `backend.hcl`, and `.terraform/` remain git-ignored

## Not done in this PR

- No remote-backend `terraform plan`/`apply`/`destroy` has been run, and no AWS resource has been created. That requires a real `backend.hcl` and `foundation.tfvars` plus separate, explicit approval per the repository's infrastructure-safety rules.

Closes #174

## Test plan

- [ ] `terraform init -backend-config=backend.hcl` against the real state bucket, then a reviewed `terraform plan -var-file=../environments/demo/foundation.tfvars -out=tfplan`
- [ ] `terraform apply "tfplan"` (separate approval)
- [ ] Verify: VPC, 2 public + 2 private subnets, IGW, 2 route tables, 2 ECR repositories (`IMMUTABLE`, lifecycle policy) exist
- [ ] Confirm no NAT Gateway / Elastic IP / VPC endpoint was created
- [ ] A separately approved `terraform destroy` removes the VPC, subnets, Internet Gateway, route tables, associations, lifecycle policies, and both ECR repositories. `force_delete` allows non-empty repositories to be removed.
