### PR TITLE
feat(infra): add MongoDB Atlas data stack (#175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,26 @@ jobs:
 
       - name: Terraform validate (foundation)
         run: terraform -chdir=infra/terraform/foundation validate
+
+  terraform-data-validate:
+    name: Terraform data validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.10.0"
+          terraform_wrapper: false
+
+      - name: Terraform fmt check (data)
+        run: terraform fmt -check -recursive infra/terraform/data
+
+      - name: Terraform init (data, no backend)
+        run: terraform -chdir=infra/terraform/data init -backend=false -lockfile=readonly
+
+      - name: Terraform validate (data)
+        run: terraform -chdir=infra/terraform/data validate

--- a/infra/terraform/data/.terraform.lock.hcl
+++ b/infra/terraform/data/.terraform.lock.hcl
@@ -1,0 +1,80 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:MhideOrA+/8rovaA9BC23G4dDrFNZ0mfrRMNptZBIS0=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "h1:lVDv+0AjDjrLfpmaJbWqUmIw/k3/AHXLc3N4m55SNdo=",
+    "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/mongodb/mongodbatlas" {
+  version     = "2.14.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:8exNk9p4srZHpAqIImQht3fXTr3uLL7+uNSMe+gIV2k=",
+    "h1:C5gS5IQrKEY8XbpL7pDQkrUWU7iigPp7jSfo87ZL1VE=",
+    "h1:Il0sZntTdbidLUiu3qOjf/3dKHGOiHx+WB6cxh96/8I=",
+    "h1:RBg4sKSz5Lmffmao7uaej0I4FmmflUusm31IbSjxkHA=",
+    "h1:UTCBwPedA+M3V0eV63l4onpa2NYKRm6ZXEJR+199Tnw=",
+    "zh:41bbee509b1fa433758457afc5a3e061dc90b163472a3df6e337c1c55cbe13d8",
+    "zh:4a0bba0b802918900f7aaf19a9b526004c425306975176319ceced3d0a55cb89",
+    "zh:557f5da217d25ec8b51efb6ce311f7197642d74db3e2a00d5ba038fcac9d61e4",
+    "zh:7955855d2ade5cbb98945d1ba9f9213a09f87a9e8114973ee443c2fb2907eb33",
+    "zh:8642e4e51fd675471b067343a19b6270577d981e55f58d3a605fd1ad324cf959",
+    "zh:8d74f4297c2a6fa70eeb73d49907c467d52173e7f49e535889cbf9569ae69819",
+    "zh:94a6f20af02576f9ff492849086531265256013defd04520adc673ede67cbff1",
+    "zh:94e3e563fc4cbd44089d02ff40c44473fff631886b2a50018682283c758cc01d",
+    "zh:a17f2140ff0d16ffeca7d4e657ed6f51e4be1080d5ba33c1053a3a3b61d0c71a",
+    "zh:aa6a3e04a1fe317306258b12e8d36f68416fefbae70e66741b7665bada98d218",
+    "zh:b553cdeecff993f96dceeac185546ad7947672224fbff02ff49b4c7bf9760e81",
+    "zh:e97dccb984037253393fc07996bb619d7d71fa82fa1f715b744e4fd449ec1f93",
+    "zh:f725d20056d02d71acaf85a5d1ee32bb9cd0c0451d3f1840c74670d58ef2647d",
+  ]
+}

--- a/infra/terraform/data/README.md
+++ b/infra/terraform/data/README.md
@@ -2,23 +2,174 @@
 
 External database wiring. Spec: §4.4. State key: `itassetpulse/demo/data.tfstate`.
 
-> Documentation-only until issue **#175** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
+## What it creates
 
-## Responsibility
+- `random_password.mongo_db_user` — a Terraform-generated password for the database user; never a
+  hand-written, version-controlled value.
+- `mongodbatlas_database_user.app` — a database user on `var.atlas_project_id`, `auth_database_name =
+  "admin"` (SCRAM authentication), with a single `readWrite` role scoped to `var.mongodb_database_name`. No
+  `scopes` block is set, so **the role applies to every cluster in the project on which that database
+  exists** — the user is not restricted to a single cluster. This stack does not introduce a cluster-scope
+  feature.
+- `aws_secretsmanager_secret.mongo_uri` + `aws_secretsmanager_secret_version.mongo_uri` — holds the full
+  `MONGO_URI` connection string the backend reads via `process.env.MONGO_URI`
+  (`backend/src/app.module.ts`). `name_prefix` (not a fixed `name`) and `recovery_window_in_days = 0` so a
+  short-lived name is never blocked by a previous same-named secret still pending deletion (spec §9).
 
-MongoDB Atlas database user with a Terraform-generated password; AWS Secrets Manager secret holding the full
-`MONGO_URI` (recovery window 0, `name_prefix`); **ARN-only output**. **No Terraform-managed Atlas IP
-allow-list** — that is a manual runbook step (spec §11). Atlas API keys come from provider **environment
-variables** (`MONGODB_ATLAS_PUBLIC_KEY` / `MONGODB_ATLAS_PRIVATE_KEY`), not tfvars.
+`data` does not depend on `foundation` (the public-Atlas design needs no VPC/ECR outputs) and manages **no**
+Atlas IP allow-list resource — allow-listing is exclusively the manual runbook below (spec §11).
 
-## Planned inputs
+## Connection string composition
 
-`project_name`, `environment`, `atlas_project_id`, `mongodb_atlas_srv_host`, `mongodb_atlas_app_name`,
-`atlas_database_username`, `mongodb_database_name`. Values from `../environments/demo/data.tfvars`.
+```
+mongodb+srv://<urlencode(username)>:<urlencode(password)>@<srv_host>/<db_name>?retryWrites=true&w=majority&authSource=admin&appName=<urlencode(app_name)>
+```
 
-## Planned outputs
+- `atlas_database_username`, the generated password, and `mongodb_atlas_app_name` are each wrapped in
+  `urlencode()` — any of them may contain characters that are not valid unescaped in a URI.
+- `authSource=admin` is explicit because the SCRAM user is created with `auth_database_name = "admin"`.
+- `mongodb_atlas_srv_host` and `mongodb_database_name` are used as plain host/path segments; their own
+  variable validation already restricts them to safe character sets (see `variables.tf`), so they are not
+  additionally URL-encoded.
 
-`mongodb_secret_arn` (never the secret value).
+## Atlas Service Account authentication
+
+Credentials are **not** Terraform variables. The empty `provider "mongodbatlas" {}` block reads them from
+the Service Account environment variables:
+
+```bash
+export MONGODB_ATLAS_CLIENT_ID=...
+export MONGODB_ATLAS_CLIENT_SECRET=...
+```
+
+The spec's originally documented `MONGODB_ATLAS_PUBLIC_KEY` / `MONGODB_ATLAS_PRIVATE_KEY` names do not match
+the current `mongodb/mongodbatlas` provider (verified against the provider's own configuration guide at
+implementation time): the current Programmatic Access Key names are `MONGODB_ATLAS_PUBLIC_API_KEY` /
+`MONGODB_ATLAS_PRIVATE_API_KEY`, and Service Account (SA) authentication is now the provider's recommended
+primary method — used here.
+
+**Required Service Account permission:** the SA must be granted the narrowest sufficient Atlas role on the
+target project — **`Project Database Access Admin`** — not `Project Owner` and not an organization-wide
+role. `Project Database Access Admin` is sufficient to create and manage a `mongodbatlas_database_user`; it
+does not grant cluster, billing, or project-membership management.
+
+Provider version constraints (`versions.tf`) pin the major line only (`~> 6.0` for `aws`, `~> 2.0` for
+`mongodbatlas`, `~> 3.0` for `random`). The specific resolved version of each provider is recorded
+exclusively by the committed `.terraform.lock.hcl` — this README intentionally does not state a version as
+"current," since that text would silently go stale on a future `terraform init -upgrade`.
+
+## Inputs / outputs
+
+- Inputs: `project_name`, `environment`, `common_tags`, `aws_region`, `atlas_project_id`,
+  `mongodb_atlas_srv_host`, `mongodb_atlas_app_name`, `atlas_database_username`, `mongodb_database_name`. See
+  `../environments/demo/data.tfvars.example`. Every Atlas/Mongo input has an explicit variable validation
+  (project ID shape, host-only SRV hostname, non-empty/whitespace-trimmed username, safe database name).
+- Outputs: **only** `mongodb_secret_arn`. The secret value is never output.
+
+## Sensitive state and plan warning
+
+- The generated password can land in the Terraform **state**.
+- The full `MONGO_URI` can land in the Terraform **state and in a saved plan file**.
+- Terraform's `sensitive = true` marking (used where applicable) only masks the normal CLI output — it does
+  **not** redact a `terraform show -json` export of a plan or state, and does not encrypt the value at rest
+  beyond the state backend's own encryption (S3 SSE-S3, per the `bootstrap` stack).
+- Treat `tfplan`/`destroy.tfplan` and the remote state with the same care as a credential file.
+
+## Read-only preflight (before every apply)
+
+The Atlas account has **two separate IP access lists** — do not conflate them:
+
+1. **Administration API access list** — an org/project-level restriction on which source IPs may call the
+   Atlas Admin API at all. If the current runtime's IP is not allowed here, every `terraform` command
+   against the `mongodbatlas` provider fails outright, independent of database connectivity.
+2. **Database deployment IP access list** — governs which client IPs may open an actual MongoDB connection
+   to the cluster. This is unrelated to Terraform's own API calls; it is the list the manual runbook below
+   adds the ECS backend task's public IP to, once the `ecs` stack (#180) exists.
+
+Before applying, verify read-only:
+
+```bash
+# Confirm the SA can reach the target project and has sufficient (not broader) permission:
+# check via the Atlas UI/API that the SA's role on atlas_project_id is exactly
+# "Project Database Access Admin", not Project Owner or an org-wide role.
+
+# Confirm the Administration API access list does not block the current runtime's IP
+# (Atlas UI: Organization Access Manager -> API Access List, or the Atlas Admin API
+# accessList endpoint for the organization).
+
+# Confirm the target username does not already exist on the project
+# (Atlas UI: Database Access, or the Atlas Admin API databaseUsers endpoint).
+
+# Confirm the Secrets Manager name_prefix does not collide with an unexpected existing secret:
+aws secretsmanager list-secrets \
+  --filters Key=name,Values="<project_name>-<environment>-mongo-uri-"
+```
+
+## Order
+
+```bash
+cd infra/terraform/data
+cp backend.hcl.example backend.hcl                                             # fill in the bootstrap-created bucket
+cp ../environments/demo/data.tfvars.example ../environments/demo/data.tfvars   # fill in real Atlas project id / SRV host
+export MONGODB_ATLAS_CLIENT_ID=...
+export MONGODB_ATLAS_CLIENT_SECRET=...
+terraform init -backend-config=backend.hcl
+terraform plan  -var-file=../environments/demo/data.tfvars -out=tfplan
+terraform apply "tfplan"
+```
+
+**Sensitive-plan handling rules:**
+- `tfplan` is git-ignored and stays local only — never attached to a PR, issue, or chat message.
+- `terraform show -json` on a plan or state is run only if strictly necessary for a specific verification,
+  never routinely.
+- Any temporary JSON scratch file produced that way is deleted immediately after use.
+- The secret **value** is never pasted into a terminal report, PR comment, or chat message; post-apply
+  verification checks only the secret's **ARN and metadata** (name, `CreatedDate`, version id) — never
+  `aws secretsmanager get-secret-value`'s `SecretString`.
+- After verification, the applied saved plan file (`tfplan`) is deleted.
+
+Apply/destroy order per spec §13: `bootstrap → account → foundation → data → (publish images) → ecs`.
+
+## Controlled destroy (separate approval required)
+
+```bash
+terraform plan \
+  -destroy \
+  -var-file=../environments/demo/data.tfvars \
+  -out=destroy.tfplan
+terraform show destroy.tfplan
+terraform apply "destroy.tfplan"
+```
+
+Post-destroy read-only verification:
+- the Atlas database user no longer exists;
+- the Secrets Manager secret is gone and not in a pending-deletion state (`recovery_window_in_days = 0`
+  means immediate deletion, not scheduled);
+- `terraform state list` is empty;
+- no stale `.tflock` remains in the state bucket;
+- `bootstrap` and `account` infrastructure are untouched;
+- the local `destroy.tfplan` is deleted after verification.
+
+## Manual MongoDB Atlas IP allow-list runbook (spec §11)
+
+There is **no Terraform-managed allow-list** and never a `0.0.0.0/0` entry. Because a Fargate task's public
+IP is dynamic and only known after the `ecs` stack (#180) exists, allow-listing the **database deployment**
+IP access list (not the Administration API one above) is a manual, temporary step, performed once the
+backend task is running:
+
+1. `ecs apply` creates the backend service/task and returns immediately (`wait_for_steady_state = false`),
+   without waiting for target health.
+2. Retrieve the backend task's ENI and current public IP (`aws ecs list-tasks` → `describe-tasks` → ENI →
+   `aws ec2 describe-network-interfaces`).
+3. Create a **temporary** Atlas project IP access-list entry for that public IP (preferably with an
+   expiry/`delete_after_date`).
+4. Wait for the backend target and ECS service to become healthy/stable
+   (`aws ecs wait services-stable`). `health_check_grace_period_seconds` (configured in `ecs`) prevents
+   premature task replacement during this manual window.
+5. After the demo, remove the entry or let it expire — this is part of teardown.
+
+**The backend task's public IP must be re-allow-listed after every task replacement or release rollout**,
+because a new task receives a new public IP. This has nothing to exercise until #180 lands; it is documented
+here because this stack owns the Atlas project wiring that runbook applies to.
 
 Implemented in: **#175**.

--- a/infra/terraform/data/backend.tf
+++ b/infra/terraform/data/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  # Partial configuration: real values come from backend.hcl (git-ignored),
+  # supplied via `terraform init -backend-config=backend.hcl`.
+  backend "s3" {}
+}

--- a/infra/terraform/data/locals.tf
+++ b/infra/terraform/data/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = merge(var.common_tags, {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Purpose     = "data"
+  })
+}

--- a/infra/terraform/data/main.tf
+++ b/infra/terraform/data/main.tf
@@ -1,0 +1,16 @@
+resource "random_password" "mongo_db_user" {
+  length  = 32
+  special = true
+}
+
+resource "mongodbatlas_database_user" "app" {
+  project_id         = var.atlas_project_id
+  username           = var.atlas_database_username
+  password           = random_password.mongo_db_user.result
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readWrite"
+    database_name = var.mongodb_database_name
+  }
+}

--- a/infra/terraform/data/outputs.tf
+++ b/infra/terraform/data/outputs.tf
@@ -1,0 +1,4 @@
+output "mongodb_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the MONGO_URI connection string. Never the secret value."
+  value       = aws_secretsmanager_secret.mongo_uri.arn
+}

--- a/infra/terraform/data/providers.tf
+++ b/infra/terraform/data/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+# Credentials come from the MONGODB_ATLAS_CLIENT_ID / MONGODB_ATLAS_CLIENT_SECRET
+# Service Account environment variables (spec §4.4) - never a provider argument
+# or a Terraform variable.
+provider "mongodbatlas" {}

--- a/infra/terraform/data/secrets.tf
+++ b/infra/terraform/data/secrets.tf
@@ -1,0 +1,33 @@
+locals {
+  # Username, password, and appName are URL-encoded because a generated
+  # password (or an operator-chosen username/app name) may contain characters
+  # that are not valid unescaped in a URI. authSource=admin is explicit
+  # because the SCRAM user above is created with auth_database_name = "admin".
+  mongo_uri = join("", [
+    "mongodb+srv://",
+    urlencode(var.atlas_database_username),
+    ":",
+    urlencode(random_password.mongo_db_user.result),
+    "@",
+    var.mongodb_atlas_srv_host,
+    "/",
+    var.mongodb_database_name,
+    "?retryWrites=true&w=majority&authSource=admin&appName=",
+    urlencode(var.mongodb_atlas_app_name),
+  ])
+}
+
+resource "aws_secretsmanager_secret" "mongo_uri" {
+  name_prefix = "${local.name_prefix}-mongo-uri-"
+
+  # Ephemeral apply/destroy cycle (spec §9): immediate deletion so a
+  # short-lived name is never blocked by a pending-deletion secret.
+  recovery_window_in_days = 0
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "mongo_uri" {
+  secret_id     = aws_secretsmanager_secret.mongo_uri.id
+  secret_string = local.mongo_uri
+}

--- a/infra/terraform/data/variables.tf
+++ b/infra/terraform/data/variables.tf
@@ -1,0 +1,81 @@
+variable "project_name" {
+  description = "Project name used to build resource names and tags."
+  type        = string
+  default     = "itassetpulse"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,32}[a-z0-9])?$", var.project_name))
+    error_message = "project_name must be 1-34 characters, lowercase letters, digits and hyphens only, and start and end with a letter or digit."
+  }
+}
+
+variable "environment" {
+  description = "Environment name used to build resource names, tags, and the remote-state key (e.g. \"demo\")."
+  type        = string
+  default     = "demo"
+}
+
+variable "common_tags" {
+  description = "Additional tags merged into every resource created by this stack."
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region where the Secrets Manager secret is created."
+  type        = string
+  default     = "eu-north-1"
+}
+
+variable "atlas_project_id" {
+  description = "MongoDB Atlas project (group) ID that owns the database user."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-f0-9]{24}$", var.atlas_project_id))
+    error_message = "atlas_project_id must be a 24-character lowercase hexadecimal Atlas project ID."
+  }
+}
+
+variable "mongodb_atlas_srv_host" {
+  description = "MongoDB Atlas cluster SRV hostname only, e.g. \"cluster0.abcde.mongodb.net\" - no scheme, credentials, path, or query string."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9.-]+$", var.mongodb_atlas_srv_host))
+    error_message = "mongodb_atlas_srv_host must be a bare hostname only (no \"mongodb+srv://\" scheme, credentials, path, or query string)."
+  }
+}
+
+variable "mongodb_atlas_app_name" {
+  description = "Application name reported to Atlas in the connection string (appName query parameter)."
+  type        = string
+
+  validation {
+    condition     = length(var.mongodb_atlas_app_name) > 0
+    error_message = "mongodb_atlas_app_name must not be empty."
+  }
+}
+
+variable "atlas_database_username" {
+  description = "Username for the Terraform-managed MongoDB Atlas database user."
+  type        = string
+
+  validation {
+    condition = (
+      length(trimspace(var.atlas_database_username)) > 0 &&
+      var.atlas_database_username == trimspace(var.atlas_database_username)
+    )
+    error_message = "atlas_database_username must not be empty or contain leading or trailing whitespace."
+  }
+}
+
+variable "mongodb_database_name" {
+  description = "Name of the application database the generated user has readWrite access to."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_-]+$", var.mongodb_database_name))
+    error_message = "mongodb_database_name must contain only letters, digits, underscores, and hyphens."
+  }
+}

--- a/infra/terraform/data/versions.tf
+++ b/infra/terraform/data/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the `data` root stack: `random_password.mongo_db_user` (Terraform-generated), `mongodbatlas_database_user.app` on `var.atlas_project_id` (`auth_database_name = "admin"`, SCRAM), with a single `readWrite` role scoped to `var.mongodb_database_name` only. No `scopes` block is set, so the role applies to every cluster in the project on which that database exists — documented explicitly, not left implicit; no cluster-scope feature is introduced.
- Adds `aws_secretsmanager_secret.mongo_uri` + `aws_secretsmanager_secret_version.mongo_uri` holding the full `MONGO_URI` the backend reads via `process.env.MONGO_URI` (`backend/src/app.module.ts`). `name_prefix` (not a fixed name) and `recovery_window_in_days = 0` for the ephemeral apply/destroy cycle (spec §9). The connection string URL-encodes the username, password, and `appName`, and includes an explicit `authSource=admin` (matching the SCRAM user's auth database). `mongodb_atlas_srv_host` and `mongodb_database_name` are validated as safe, plain segments and are not re-encoded.
- **Output is exactly one value**: `mongodb_secret_arn`. The secret value, the generated password, and the full `MONGO_URI` are never output.
- Atlas authentication uses **Service Account (SA)** credentials (`MONGODB_ATLAS_CLIENT_ID` / `MONGODB_ATLAS_CLIENT_SECRET`), read by an empty `provider "mongodbatlas" {}` block from environment variables only — never a Terraform variable, never in tfvars or state as an input. The spec's originally documented `MONGODB_ATLAS_PUBLIC_KEY` / `MONGODB_ATLAS_PRIVATE_KEY` names are stale against the current provider (verified via the Terraform MCP against provider v2.14.0's own configuration guide); SA is now the provider's recommended primary method.
- README documents: the required Atlas Service Account permission (`Project Database Access Admin`, not `Project Owner`), a read-only preflight distinguishing the Atlas **Administration API** IP access list from the **database deployment** IP access list, explicit sensitive-state/plan warnings (generated password and full `MONGO_URI` can land in state and in a saved plan; `sensitive = true` only masks CLI output, not a JSON export), the apply runbook with saved-plan handling rules, a controlled-destroy runbook, and the manual MongoDB Atlas IP allow-list runbook from spec §11 (nothing to exercise until the `ecs` stack, #180, exists).
- Commits `infra/terraform/data/.terraform.lock.hcl` for `hashicorp/aws ~> 6.0`, `mongodb/mongodbatlas ~> 2.0`, `hashicorp/random ~> 3.0`, with the same 5-platform coverage as the existing stacks. Provider version constraints pin the major line only; no README text or comment states a resolved version as "current" — only the lock file does.
- Adds a `terraform-data-validate` CI job (`.github/workflows/ci.yml`), mirroring `terraform-foundation-validate`: `terraform fmt -check -recursive`, `terraform init -backend=false -lockfile=readonly`, `terraform validate` for `infra/terraform/data`. No AWS or Atlas credentials required — `terraform validate` only checks configuration statically. Scoped to `data` only; generalizing CI validation to every stack stays #176's scope.

## AWS/Atlas-free quality gates run

- `terraform fmt -check -recursive infra/terraform/data` — passes
- `terraform init -backend=false -lockfile=readonly` + `terraform validate` for `data` — succeeds
- `git diff --check` — no whitespace errors
- Line-item content verification against the staged diff: no credential argument on the `mongodbatlas` provider block; SA credentials appear only as documented env-var names, never real values; no `MONGO_URI` or password output; only `mongodb_secret_arn` is output; username/password/`appName` are `urlencode()`-d; `authSource=admin` present; `readWrite` role scoped to the configured database only; no Terraform-managed Atlas IP access list resource anywhere in `data/`; secret uses `name_prefix`; `recovery_window_in_days = 0`; `.terraform.lock.hcl` staged; no `backend.hcl`, `.tfvars`, state, saved plan, or `.terraform/` content staged

## Not done in this PR

- No remote-backend `terraform plan`/`apply`/`destroy` has been run, and no Atlas/AWS resource has been created. That requires real `backend.hcl` + `data.tfvars` plus a live Atlas Service Account credential and separate, explicit approval per the repository's infrastructure-safety rules.

Closes #175

## Test plan

- [ ] Read-only preflight: confirm the SA's role on the target Atlas project is exactly `Project Database Access Admin`; confirm the Administration API IP access list does not block the runtime; confirm the target `atlas_database_username` does not already exist; confirm the Secrets Manager `name_prefix` does not collide with an existing secret
- [ ] `terraform init -backend-config=backend.hcl` against the real state bucket, then a reviewed `terraform plan -var-file=../environments/demo/data.tfvars -out=tfplan`
- [ ] `terraform apply "tfplan"` (separate approval); verify only the secret's ARN and metadata, never `get-secret-value`'s `SecretString`
- [ ] Controlled destroy (separate approval): saved `-destroy` plan review, then apply; verify the Atlas user and secret are gone, `terraform state list` is empty, no stale `.tflock`, `bootstrap`/`account` untouched