### PR TITLE
feat(infra): add reusable ECS Fargate service module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,26 @@ jobs:
 
       - name: Terraform validate (data)
         run: terraform -chdir=infra/terraform/data validate
+
+  terraform-ecs-fargate-service-validate:
+    name: Terraform ecs-fargate-service module validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.10.0"
+          terraform_wrapper: false
+
+      - name: Terraform fmt check (modules/ecs-fargate-service)
+        run: terraform fmt -check -recursive infra/terraform/modules/ecs-fargate-service
+
+      - name: Terraform init (modules/ecs-fargate-service, no backend)
+        run: terraform -chdir=infra/terraform/modules/ecs-fargate-service init -backend=false
+
+      - name: Terraform validate (modules/ecs-fargate-service)
+        run: terraform -chdir=infra/terraform/modules/ecs-fargate-service validate

--- a/docs/infrastructure-modularization-spec.md
+++ b/docs/infrastructure-modularization-spec.md
@@ -215,7 +215,17 @@ State key: `itassetpulse/demo/ecs.tfstate`. The application stack. Reads remote 
 `data`, and `account`.
 
 - ECS cluster.
-- `modules/ecs-fargate-service` instantiated twice (frontend, backend), each with `desired_count = 1`.
+- **Target groups** (frontend, backend) and their **health check configuration** (path, interval, timeout,
+  healthy/unhealthy threshold, matcher). Owned here, not by `modules/ecs-fargate-service`: AWS requires a
+  target group to already be attached to a listener/listener rule before an ECS service can reference it in
+  its `load_balancer` block, so the target group must be created next to the ALB/listener that attaches it,
+  not inside the reusable service module (which is called before the listener rule that would otherwise need
+  to depend on it — a dependency direction that cannot be expressed across a module boundary). `target_type =
+  "ip"` (Fargate `awsvpc` requirement).
+- `modules/ecs-fargate-service` instantiated twice (frontend, backend), each with `desired_count = 1` and the
+  matching target group ARN passed in as `target_group_arn`. Each `module` block carries an explicit
+  `depends_on` on the listener rule that attaches its target group, so the target group is guaranteed to be
+  "behind" a listener before the module's ECS service is created.
 - Internet-facing ALB, ALB security group, HTTP listener. **ALB security-group contract:** ingress TCP 80 from
   `0.0.0.0/0`; egress TCP 80 to the frontend task security group; egress TCP 3000 to the backend task security
   group.
@@ -277,19 +287,23 @@ The shared pattern of the two single-container Fargate services. Used by **two e
 - Inputs: `name`, `cluster_arn`, `common_tags`, `project_name`, `environment`, `container_image`
   (digest-pinned URI), `container_port`, `desired_count`, `cpu`, `memory`, `public_subnet_ids`,
   `assign_public_ip`, `alb_security_group_id`, `vpc_id`, `environment_variables`, `secrets`
-  (name → Secrets Manager ARN), `health_check_path`, `health_check_grace_period_seconds`,
+  (name → Secrets Manager ARN), `target_group_arn` (Elastic Load Balancing target group ARN, created and
+  attached to a listener/listener rule by the `ecs` root stack — see §4.5), `health_check_grace_period_seconds`,
   `deployment_min_healthy_percent`, `deployment_max_percent`, `log_retention_days`. **No role ARNs are passed
-  in.**
+  in. No `health_check_path` input** — health check configuration lives on the target group, which this module
+  does not create (§4.5).
 - IAM ownership: the module **creates its own task execution role**, grants the standard ECR pull and
   CloudWatch Logs permissions, and derives a **narrowly scoped** `secretsmanager:GetSecretValue` policy from
   exactly the ARNs in the supplied `secrets` map (no `Resource = "*"`). The module does **not** create a task
   role, because the application makes no AWS API calls at runtime; a task role would only be added if a future
   need for AWS API access appears.
-- Resources: CloudWatch log group; ECS task definition; ECS service; **task execution role + its scoped
-  policies**; service-specific security group with **explicit rules** — inbound only from the ALB security
-  group on the container port, and **explicit egress** (see below); target group; container port mapping;
-  health check configuration; deployment min/max healthy percentages; public-subnet networking with
-  `assign_public_ip`; environment and Secrets Manager injection via the task definition `secrets` field.
+- Resources: CloudWatch log group; ECS task definition; ECS service (its `load_balancer` block targets the
+  caller-supplied `target_group_arn`); **task execution role + its scoped policies**; service-specific security
+  group with **explicit rules** — inbound only from the ALB security group on the container port, and
+  **explicit egress** (see below); container port mapping; deployment min/max healthy percentages;
+  public-subnet networking with `assign_public_ip`; environment and Secrets Manager injection via the task
+  definition `secrets` field. **No target group and no health check configuration** — both are owned by the
+  `ecs` root stack (§4.5).
 - Egress (explicit, not implicit): the service security group permits the outbound access the tasks actually
   need over the public internet — ECR image pull, CloudWatch Logs, Secrets Manager, DNS, and (backend) the
   MongoDB Atlas endpoint. For v1 this is implemented as **allow-all egress (`0.0.0.0/0`), documented** as an
@@ -297,15 +311,16 @@ The shared pattern of the two single-container Fargate services. Used by **two e
 - Apply behavior: the ECS service sets **`wait_for_steady_state = false`** (fixed in v1, **not** a module
   input), so `terraform apply` creates the service and task and returns without waiting for backend target
   health. This is what enables the manual Atlas allow-list window (see §11).
-- Outputs: `service_name`, `target_group_arn`, `security_group_id`, `log_group_name`, `task_definition_arn`,
-  `execution_role_arn`.
+- Outputs: `service_name`, `security_group_id`, `log_group_name`, `task_definition_arn`, `execution_role_arn`.
+  **No `target_group_arn` output** — the module receives the target group ARN as an input, it does not produce
+  one.
 - Deliberate limits: this is **not** a universal ECS platform module. No arbitrary container count, no sidecar
   abstraction, no capacity-provider combinations, no blue/green, no Service Connect, no Cloud Map, no
   deployment-controller choice, no arbitrary IAM policy JSON input, and no excessive optional dynamic blocks.
   If the frontend and backend needs diverge too much, prefer some repetition over a complex conditional module.
 
-Everything else (ALB, listeners, routing, URL rewrite, ECR digest lookup, release-SHA selection, JWT secret,
-alarms, dashboard, SNS wiring) stays in the `ecs` root stack.
+Everything else (ALB, listeners, routing, URL rewrite, target groups, health check configuration, ECR digest
+lookup, release-SHA selection, JWT secret, alarms, dashboard, SNS wiring) stays in the `ecs` root stack.
 
 ---
 

--- a/infra/terraform/ecs/README.md
+++ b/infra/terraform/ecs/README.md
@@ -7,11 +7,22 @@ The ECS Fargate application stack. Spec: §4.5. State key: `itassetpulse/demo/ec
 
 ## Responsibility
 
-ECS cluster; frontend and backend `modules/ecs-fargate-service` instances (`desired_count = 1` each); JWT
-Secrets Manager secret + minimal IAM; ECR image **digest lookup** driven by `release_sha`; internet-facing ALB
-and ALB security group; HTTP listener; default rule → frontend, `/api` + `/api/*` rule → backend with the
-`url-rewrite` transform `^/api/?(.*)$` → `/$1`; CloudWatch log groups, alarms, and one dashboard. Reads
-`foundation`, `data`, and `account` remote state (SNS topic ARN from `account`).
+ECS cluster; **target groups (frontend, backend) and their health check configuration** (owned here, not by
+`modules/ecs-fargate-service` — see below); frontend and backend `modules/ecs-fargate-service` instances
+(`desired_count = 1` each) called with the matching `target_group_arn` and an explicit `depends_on` on the
+listener rule that attaches it; JWT Secrets Manager secret + minimal IAM; ECR image **digest lookup** driven by
+`release_sha`; internet-facing ALB and ALB security group; HTTP listener; default rule → frontend, `/api` +
+`/api/*` rule → backend with the `url-rewrite` transform `^/api/?(.*)$` → `/$1`; CloudWatch log groups, alarms,
+and one dashboard. Reads `foundation`, `data`, and `account` remote state (SNS topic ARN from `account`).
+
+**Target group ownership.** The target groups live here, not in `modules/ecs-fargate-service`, because AWS
+requires a target group to already be attached to a listener/listener rule before an ECS service can reference
+it in its `load_balancer` block. If the reusable module created both the target group and the ECS service, the
+module's internal service resource could never be made to depend on a listener rule that the caller builds
+*from* the module's own output — that dependency direction isn't expressible across a module boundary. Keeping
+the target group next to the ALB/listener it is coupled with, and passing its ARN into the module as
+`target_group_arn`, keeps the full `target group → listener/listener rule → ECS service` chain inside one
+`terraform apply` with a normal, expressible `depends_on`.
 
 ## Planned inputs
 

--- a/infra/terraform/modules/ecs-fargate-service/README.md
+++ b/infra/terraform/modules/ecs-fargate-service/README.md
@@ -3,32 +3,82 @@
 The shared pattern for a single-container Fargate service. Instantiated twice by `ecs` (frontend, backend) as
 **two explicit module blocks** (not a `for_each` map). Spec: §5.3.
 
-> Documentation-only until issue **#179** adds the Terraform configuration. No `.tf` here yet — do not run
-> Terraform against this directory.
-
 ## Responsibility
 
-CloudWatch log group; ECS task definition; ECS service (`wait_for_steady_state = false`, fixed in v1); service
-security group with **explicit** ingress (only from the ALB SG on the container port) and **explicit** egress;
-target group; health check; deployment min/max healthy percentages; public-subnet networking with
-`assign_public_ip`; environment and Secrets Manager injection. The module **creates its own task execution
-role**, scoped to exactly the ARNs in the `secrets` map (empty map ⇒ no policy). **No task role** is created
-(the app makes no AWS API calls at runtime).
+CloudWatch log group; ECS task definition; ECS service (`wait_for_steady_state = false`, fixed in v1; no
+`deployment_circuit_breaker` block — see "Deployment circuit breaker" below); service security group with
+**explicit** ingress (only from the ALB SG on the container port) and **explicit** egress; deployment min/max
+healthy percentages; public-subnet networking with `assign_public_ip`; environment and Secrets Manager
+injection. The module **creates its own task execution role**, scoped to exactly the ARNs in the `secrets` map
+(empty map ⇒ no policy). **No task role** is created (the app makes no AWS API calls at runtime). The module
+has no `provider` block — the caller's `aws` provider is used.
 
 Deliberately **not** a universal ECS module: no arbitrary container count, sidecars, capacity providers,
 blue/green, Service Connect, Cloud Map, or arbitrary IAM policy JSON.
 
-## Planned inputs
+## Target group ownership (moved to the `ecs` root stack)
 
-`name`, `cluster_arn`, `common_tags`, `project_name`, `environment`, `container_image` (digest-pinned),
-`container_port`, `desired_count`, `cpu`, `memory`, `public_subnet_ids`, `assign_public_ip`,
-`alb_security_group_id`, `vpc_id`, `environment_variables`, `secrets`, `health_check_path`,
-`health_check_grace_period_seconds`, `deployment_min_healthy_percent`, `deployment_max_percent`,
-`log_retention_days`.
+This module does **not** create a target group and does **not** configure a health check. AWS requires a
+target group to already be attached to a load balancer listener/listener rule before an ECS service can
+reference it in its `load_balancer` block. If this module created both the target group and the ECS service,
+the service (created inside the module) could never be made to depend on the listener rule that the caller
+(`ecs` root stack, #180) builds *from* the module's own `target_group_arn` output — that dependency direction
+cannot be expressed across a module boundary without a graph problem. Instead, the `ecs` root stack creates the
+target group next to the ALB and listener it is coupled with, and passes the ARN in as the `target_group_arn`
+input. The `ecs` root stack's `module` block additionally sets an explicit `depends_on` on the listener rule
+that attaches the target group, so the target group is guaranteed to be "behind" a listener before this
+module's ECS service is created — keeping the whole `target group → listener/listener rule → ECS service`
+chain inside a single `terraform apply`.
 
-## Planned outputs
+## Deployment circuit breaker
 
-`service_name`, `target_group_arn`, `security_group_id`, `log_group_name`, `task_definition_arn`,
-`execution_role_arn`.
+Not enabled in v1. The circuit breaker's failure detection relies on the service's ELB health checks passing;
+in this project's design, the backend target intentionally stays unhealthy until an operator completes the
+manual MongoDB Atlas IP allow-list step (spec §11). Enabling automatic rollback would fight that design by
+rolling back before the operator finishes the manual step. `wait_for_steady_state = false` is set for the same
+reason.
+
+## Inputs
+
+`name`, `cluster_arn`, `common_tags`, `project_name`, `environment`, `container_image` (digest-pinned URI,
+validated — see below), `container_port`, `desired_count`, `cpu`, `memory` (validated against the supported
+Fargate CPU/memory pairs — see below), `public_subnet_ids`, `assign_public_ip`, `alb_security_group_id`,
+`vpc_id`, `environment_variables` (map(string)), `secrets` (map(string), name → Secrets Manager ARN),
+`target_group_arn` (Elastic Load Balancing target group ARN, created and attached to a listener/listener rule
+by the `ecs` root stack), `health_check_grace_period_seconds`, `deployment_min_healthy_percent`,
+`deployment_max_percent`, `log_retention_days`. **No role ARN input** (the module creates its own execution
+role). **No `health_check_path` input** — health check configuration lives on the target group, owned by the
+`ecs` root stack.
+
+### `container_image` validation
+
+Must be a digest-pinned URI: `<repository-uri>@sha256:<64 lowercase hex characters>`. Tags (including
+`latest` or a Git SHA tag), whitespace, and multiple `@` characters are rejected. The `ecs` root stack produces
+this value via `data "aws_ecr_image"` digest lookup driven by `release_sha`; this module only validates the
+final format.
+
+### `target_group_arn` validation
+
+Must be a fully-formed Elastic Load Balancing target group ARN
+(`arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/<name>/<id>`).
+
+### Fargate CPU/memory validation
+
+`cpu` and `memory` are `number` inputs (converted to strings for the task definition, since the AWS API fields
+are strings). A `lifecycle.precondition` on the task definition checks the pair against the full documented
+Linux/X86_64 Fargate CPU → memory (MiB) option table, using a safe `lookup(..., [])` so an unrecognized `cpu`
+value produces this module's own error message instead of an index error.
+
+### Platform version and runtime platform
+
+CPU sizes 8192 and 16384 require at least Linux platform version `1.4.0`. The service sets
+`platform_version = "1.4.0"` explicitly (not an input — a fixed, documented choice) rather than relying on the
+`LATEST` default. The task definition pins `runtime_platform { operating_system_family = "LINUX",
+cpu_architecture = "X86_64" }`. No ARM64 option in this module.
+
+## Outputs
+
+`service_name`, `security_group_id`, `log_group_name`, `task_definition_arn`, `execution_role_arn`. **No
+`target_group_arn` output** — the module receives the target group ARN as an input, it does not produce one.
 
 Implemented in: **#179** (consumed by the `ecs` core stack, #180).

--- a/infra/terraform/modules/ecs-fargate-service/iam.tf
+++ b/infra/terraform/modules/ecs-fargate-service/iam.tf
@@ -1,0 +1,46 @@
+data "aws_iam_policy_document" "execution_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${local.name_prefix}-execution"
+  assume_role_policy = data.aws_iam_policy_document.execution_assume_role.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Scoped to exactly the ARNs in var.secrets. No policy is created for an empty
+# map, and this policy never grants kms:Decrypt: the demo secrets (Mongo URI,
+# JWT secret) use the AWS-managed (SSE) key, not a customer-managed KMS key.
+# A future customer-managed key would need a separate, explicitly scoped
+# kms:Decrypt grant on that key's ARN.
+data "aws_iam_policy_document" "secrets_access" {
+  count = length(var.secrets) > 0 ? 1 : 0
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = values(var.secrets)
+  }
+}
+
+resource "aws_iam_role_policy" "secrets_access" {
+  count = length(var.secrets) > 0 ? 1 : 0
+
+  name   = "${local.name_prefix}-secrets-access"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.secrets_access[0].json
+}

--- a/infra/terraform/modules/ecs-fargate-service/locals.tf
+++ b/infra/terraform/modules/ecs-fargate-service/locals.tf
@@ -1,0 +1,40 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}-${var.name}"
+
+  common_tags = merge(var.common_tags, {
+    Project     = var.project_name
+    Environment = var.environment
+    Service     = var.name
+    ManagedBy   = "terraform"
+    Purpose     = "ecs-fargate-service"
+  })
+
+  # Full documented Linux/X86_64 Fargate CPU (vCPU units) -> memory (MiB) option table.
+  fargate_cpu_memory_options = {
+    "256"   = [512, 1024, 2048]
+    "512"   = [1024, 2048, 3072, 4096]
+    "1024"  = range(2048, 8193, 1024)
+    "2048"  = range(4096, 16385, 1024)
+    "4096"  = range(8192, 30721, 1024)
+    "8192"  = range(16384, 61441, 4096)
+    "16384" = range(32768, 122881, 8192)
+    "32768" = [61440, 122880, 249856]
+  }
+
+  # CPU sizes 8192 and 16384 require at least Linux platform version 1.4.0.
+  ecs_platform_version = "1.4.0"
+
+  environment_variables_list = [
+    for k in sort(keys(var.environment_variables)) : {
+      name  = k
+      value = var.environment_variables[k]
+    }
+  ]
+
+  secrets_list = [
+    for k in sort(keys(var.secrets)) : {
+      name      = k
+      valueFrom = var.secrets[k]
+    }
+  ]
+}

--- a/infra/terraform/modules/ecs-fargate-service/log_group.tf
+++ b/infra/terraform/modules/ecs-fargate-service/log_group.tf
@@ -1,0 +1,6 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = var.log_retention_days
+
+  tags = local.common_tags
+}

--- a/infra/terraform/modules/ecs-fargate-service/outputs.tf
+++ b/infra/terraform/modules/ecs-fargate-service/outputs.tf
@@ -1,0 +1,24 @@
+output "service_name" {
+  description = "Name of the ECS service."
+  value       = aws_ecs_service.this.name
+}
+
+output "security_group_id" {
+  description = "ID of the service's security group."
+  value       = aws_security_group.this.id
+}
+
+output "log_group_name" {
+  description = "Name of the CloudWatch log group."
+  value       = aws_cloudwatch_log_group.this.name
+}
+
+output "task_definition_arn" {
+  description = "ARN of the ECS task definition."
+  value       = aws_ecs_task_definition.this.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the task execution role."
+  value       = aws_iam_role.execution.arn
+}

--- a/infra/terraform/modules/ecs-fargate-service/security_group.tf
+++ b/infra/terraform/modules/ecs-fargate-service/security_group.tf
@@ -1,0 +1,33 @@
+resource "aws_security_group" "this" {
+  name        = "${local.name_prefix}-service"
+  description = "Fargate service security group for ${local.name_prefix}"
+  vpc_id      = var.vpc_id
+
+  tags = local.common_tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "from_alb" {
+  security_group_id = aws_security_group.this.id
+  description       = "Container port from the ALB security group"
+
+  referenced_security_group_id = var.alb_security_group_id
+  from_port                    = var.container_port
+  to_port                      = var.container_port
+  ip_protocol                  = "tcp"
+
+  tags = local.common_tags
+}
+
+# Explicit allow-all egress (documented ephemeral-demo decision, spec §5.3):
+# tasks need outbound access to ECR, CloudWatch Logs, Secrets Manager, DNS,
+# and (backend) the public MongoDB Atlas endpoint. Tighter per-port/
+# destination egress is a deferred hardening item, not v1 scope.
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.this.id
+  description       = "Allow-all egress (ephemeral demo; see spec §5.3)"
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "-1"
+
+  tags = local.common_tags
+}

--- a/infra/terraform/modules/ecs-fargate-service/service.tf
+++ b/infra/terraform/modules/ecs-fargate-service/service.tf
@@ -1,0 +1,38 @@
+resource "aws_ecs_service" "this" {
+  name             = local.name_prefix
+  cluster          = var.cluster_arn
+  task_definition  = aws_ecs_task_definition.this.arn
+  desired_count    = var.desired_count
+  launch_type      = "FARGATE"
+  platform_version = local.ecs_platform_version
+
+  # Fixed in v1 (not an input): lets terraform apply return without waiting
+  # for backend target health, which is what enables the manual MongoDB
+  # Atlas allow-list window (spec §11). No deployment_circuit_breaker block
+  # for the same reason - automatic rollback-on-health-check-failure would
+  # fight that manual window.
+  wait_for_steady_state = false
+
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+  deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
+  deployment_maximum_percent         = var.deployment_max_percent
+
+  network_configuration {
+    subnets          = var.public_subnet_ids
+    security_groups  = [aws_security_group.this.id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = var.name
+    container_port   = var.container_port
+  }
+
+  tags = local.common_tags
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution_managed,
+    aws_iam_role_policy.secrets_access,
+  ]
+}

--- a/infra/terraform/modules/ecs-fargate-service/task_definition.tf
+++ b/infra/terraform/modules/ecs-fargate-service/task_definition.tf
@@ -1,0 +1,56 @@
+data "aws_region" "current" {}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = local.name_prefix
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = aws_iam_role.execution.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = var.name
+      image     = var.container_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = local.environment_variables_list
+      secrets     = local.secrets_list
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.this.name
+          "awslogs-region"        = data.aws_region.current.region
+          "awslogs-stream-prefix" = var.name
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+
+  lifecycle {
+    precondition {
+      # Safe lookup with a [] default: an unrecognized cpu value falls through
+      # to this module's own error message instead of an "Invalid index" crash.
+      condition = contains(
+        lookup(local.fargate_cpu_memory_options, tostring(var.cpu), []),
+        var.memory
+      )
+      error_message = "cpu/memory (${var.cpu}/${var.memory}) is not a supported AWS Fargate CPU/memory pair. See local.fargate_cpu_memory_options for the supported combinations."
+    }
+  }
+}

--- a/infra/terraform/modules/ecs-fargate-service/variables.tf
+++ b/infra/terraform/modules/ecs-fargate-service/variables.tf
@@ -1,0 +1,155 @@
+variable "name" {
+  description = "Short name of the service (e.g. \"backend\", \"frontend\"), combined with project_name/environment for resource names."
+  type        = string
+}
+
+variable "cluster_arn" {
+  description = "ARN of the ECS cluster the service runs in."
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Tags applied to every taggable resource created by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "project_name" {
+  description = "Project name used to build resource names and tags."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used to build resource names and tags (e.g. \"demo\")."
+  type        = string
+}
+
+variable "container_image" {
+  description = "Digest-pinned container image URI (<repository-uri>@sha256:<64 lowercase hex characters>). Mutable tags are not accepted."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@[:space:]]+@sha256:[0-9a-f]{64}$", var.container_image))
+    error_message = "container_image must be a digest-pinned URI in the form <repository-uri>@sha256:<64 lowercase hex characters>; tags (including \"latest\" or a Git SHA tag), whitespace, and multiple \"@\" characters are not accepted."
+  }
+}
+
+variable "container_port" {
+  description = "Port the container listens on."
+  type        = number
+
+  validation {
+    condition     = var.container_port >= 1 && var.container_port <= 65535 && floor(var.container_port) == var.container_port
+    error_message = "container_port must be a whole number between 1 and 65535."
+  }
+}
+
+variable "desired_count" {
+  description = "Desired number of running tasks."
+  type        = number
+
+  validation {
+    condition     = var.desired_count >= 0 && floor(var.desired_count) == var.desired_count
+    error_message = "desired_count must be a non-negative whole number."
+  }
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units (e.g. 256, 512, 1024). Must be paired with a supported memory value."
+  type        = number
+}
+
+variable "memory" {
+  description = "Fargate task memory in MiB. Must be a value supported for the given cpu (see locals.fargate_cpu_memory_options)."
+  type        = number
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs the task ENI is placed in."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_ids) > 0
+    error_message = "public_subnet_ids must contain at least one subnet ID."
+  }
+}
+
+variable "assign_public_ip" {
+  description = "Whether tasks receive a public IP (required for public-subnet Fargate with no NAT Gateway)."
+  type        = bool
+}
+
+variable "alb_security_group_id" {
+  description = "Security group ID of the ALB; the only allowed ingress source for this service's security group."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID the service security group is created in."
+  type        = string
+}
+
+variable "environment_variables" {
+  description = "Plain (non-secret) environment variables injected into the container, as name => value."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Secrets Manager-backed environment variables, as name => secret ARN. Empty map creates no IAM policy."
+  type        = map(string)
+  default     = {}
+}
+
+variable "target_group_arn" {
+  description = "ARN of the ALB target group this service registers with. Created and attached to a listener/listener rule by the ecs root stack; this module does not create a target group."
+  type        = string
+
+  validation {
+    condition     = can(regex("^arn:aws:elasticloadbalancing:[a-z0-9-]+:[0-9]{12}:targetgroup/[A-Za-z0-9-]+/[0-9a-f]+$", var.target_group_arn))
+    error_message = "target_group_arn must be a fully-formed Elastic Load Balancing target group ARN (arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/<name>/<id>)."
+  }
+}
+
+variable "health_check_grace_period_seconds" {
+  description = "Seconds the ECS service ignores failing health checks after a task starts, so the manual MongoDB Atlas allow-list step (spec §11) doesn't cause premature task replacement."
+  type        = number
+
+  validation {
+    condition     = var.health_check_grace_period_seconds >= 0 && floor(var.health_check_grace_period_seconds) == var.health_check_grace_period_seconds
+    error_message = "health_check_grace_period_seconds must be a whole number greater than or equal to 0."
+  }
+}
+
+variable "deployment_min_healthy_percent" {
+  description = "Minimum healthy percent during deployments."
+  type        = number
+
+  validation {
+    condition     = var.deployment_min_healthy_percent >= 0 && var.deployment_min_healthy_percent <= 100 && floor(var.deployment_min_healthy_percent) == var.deployment_min_healthy_percent
+    error_message = "deployment_min_healthy_percent must be a whole number between 0 and 100."
+  }
+}
+
+variable "deployment_max_percent" {
+  description = "Maximum percent during deployments."
+  type        = number
+
+  validation {
+    condition     = var.deployment_max_percent >= 100 && var.deployment_max_percent <= 200 && floor(var.deployment_max_percent) == var.deployment_max_percent
+    error_message = "deployment_max_percent must be a whole number between 100 and 200."
+  }
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention period in days for the service's log group."
+  type        = number
+
+  validation {
+    condition = contains(
+      [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.log_retention_days
+    )
+    error_message = "log_retention_days must be one of the values CloudWatch Logs accepts for retention_in_days (e.g. 1, 3, 5, 7, 14, 30, 60, 90, ...)."
+  }
+}

--- a/infra/terraform/modules/ecs-fargate-service/versions.tf
+++ b/infra/terraform/modules/ecs-fargate-service/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #179

## Summary

Implements the reusable `modules/ecs-fargate-service` Terraform module (frontend/backend Fargate service
pattern), with one significant contract change from the original issue text, decided and documented during
planning: **target group ownership moves to the `ecs` core stack (#180)**.

### Target group ownership

AWS requires a target group to already be attached to a load balancer listener/listener rule before an ECS
service can reference it in its `load_balancer` block. If this module created both the target group and the
ECS service, the service (inside the module) could never be made to depend on a listener rule that the caller
builds *from* the module's own `target_group_arn` output — that dependency direction can't be expressed across
a module boundary in a single `terraform apply`. The target group (and its health check configuration) now
lives in the `ecs` root stack, next to the ALB/listener it is coupled with; this module takes `target_group_arn`
as an input instead of creating and outputting one.

### Module contract (final)

- **Inputs:** `name`, `cluster_arn`, `common_tags`, `project_name`, `environment`, `container_image`
  (digest-pinned, validated), `container_port`, `desired_count`, `cpu`, `memory` (validated against the full
  Linux/X86_64 Fargate CPU/memory table), `public_subnet_ids`, `assign_public_ip`, `alb_security_group_id`,
  `vpc_id`, `environment_variables`, `secrets`, `target_group_arn` (ARN-validated),
  `health_check_grace_period_seconds`, `deployment_min_healthy_percent`, `deployment_max_percent`,
  `log_retention_days`. No `health_check_path` input, no role ARN input.
- **Outputs:** `service_name`, `security_group_id`, `log_group_name`, `task_definition_arn`,
  `execution_role_arn`. No `target_group_arn` output.

### What's in the module

- Digest-pinned `container_image` validation (rejects tags, whitespace, multiple `@`).
- Full Linux/X86_64 Fargate CPU/memory validation table with a safe `lookup(..., [])` precondition.
- `platform_version = "1.4.0"` and `runtime_platform { LINUX / X86_64 }` pinned explicitly.
- Self-created task execution role (`AmazonECSTaskExecutionRolePolicy` + optional, ARN-scoped
  `secretsmanager:GetSecretValue` policy — only when `secrets` is non-empty, no `Resource = "*"`, no
  `kms:Decrypt`).
- Service security group with explicit ingress (ALB SG → container port only) and documented allow-all egress.
- ECS task definition and service (`wait_for_steady_state = false`, no deployment circuit breaker — both
  intentional, documented decisions tied to the manual MongoDB Atlas allow-list window, spec §11).

### What's explicitly not in this PR

No task role, no target group, no ALB/listener, no deployment circuit breaker, no `terraform apply`, no AWS
runtime resources.

### CI

New AWS-free `terraform-ecs-fargate-service-validate` job (`fmt -check`, `init -backend=false`, `validate`
directly on the module directory — it has no consuming root stack yet). The existing six CI jobs are
unchanged.

Actual runtime verification (cluster, ALB, target groups, listener rules, live `ecs apply`) is part of the
`ecs` core stack, #180.
