### PR TITLE
feat(infra): add ECS core application stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,26 @@ jobs:
 
       - name: Terraform validate (modules/ecs-fargate-service)
         run: terraform -chdir=infra/terraform/modules/ecs-fargate-service validate
+
+  terraform-ecs-validate:
+    name: Terraform ecs validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.10.0"
+          terraform_wrapper: false
+
+      - name: Terraform fmt check (ecs)
+        run: terraform fmt -check -recursive infra/terraform/ecs
+
+      - name: Terraform init (ecs, no backend)
+        run: terraform -chdir=infra/terraform/ecs init -backend=false -lockfile=readonly
+
+      - name: Terraform validate (ecs)
+        run: terraform -chdir=infra/terraform/ecs validate

--- a/docs/infrastructure-modularization-spec.md
+++ b/docs/infrastructure-modularization-spec.md
@@ -211,8 +211,10 @@ public-Atlas design needs no VPC or ECR outputs). Atlas allow-listing is exclusi
 
 ### 4.5 `ecs` — remote state, ephemeral
 
-State key: `itassetpulse/demo/ecs.tfstate`. The application stack. Reads remote state from `foundation`,
-`data`, and `account`.
+State key: `itassetpulse/demo/ecs.tfstate`. The application stack, delivered in two increments: the core
+compute/routing increment reads remote state from `foundation` and `data` only; the observability increment
+(alarms, dashboard, SNS wiring — see the last two bullets below) adds a read of the `account` remote state
+for the SNS topic ARN. Until the observability increment lands, `ecs` reads only `foundation` and `data`.
 
 - ECS cluster.
 - **Target groups** (frontend, backend) and their **health check configuration** (path, interval, timeout,
@@ -233,8 +235,10 @@ State key: `itassetpulse/demo/ecs.tfstate`. The application stack. Reads remote 
   backend target group with the `url-rewrite` transform `^/api/?(.*)$` → `/$1`.
 - `release_sha` input and ECR image **digest lookup** for immutable image pinning.
 - JWT Secrets Manager secret (application-owned) and the minimal IAM to read it.
-- CloudWatch log groups (7-day retention), alarms, and one concise dashboard.
-- SNS topic ARN consumed from the `account` remote state (used by the alarms).
+- CloudWatch log groups (7-day retention) — core increment. Alarms and one concise dashboard —
+  observability increment.
+- SNS topic ARN consumed from the `account` remote state (used by the alarms) — observability increment
+  only; the core increment does not read the `account` remote state.
 
 The ALB, listener, and routing rules stay in the root stack (they express this application's specific topology
 and are not generic). No DNS alias, no HTTPS, no autoscaling in v1.
@@ -348,8 +352,9 @@ Dependency graph (one-directional, no cycles):
   foundation ── independent
   data       ── independent of foundation (public-Atlas design)
 
-  ecs        ── reads remote state of: foundation, data, account
-                (SNS topic ARN comes from the account remote state)
+  ecs        ── core increment reads remote state of: foundation, data
+                observability increment adds: account
+                (SNS topic ARN comes from the account remote state, observability increment only)
 
   eks (later)── reads remote state of: foundation, data (and account as needed);
                 independent of ecs
@@ -393,8 +398,9 @@ persistent layers).
 - `data`: `atlas_project_id`, `mongodb_atlas_srv_host`, `mongodb_atlas_app_name`, `atlas_database_username`,
   `mongodb_database_name`. The Atlas **API keys are not variables** — they come from the provider environment
   variables (see §4.4). The database password is generated (`random_password`), not supplied.
-- `ecs`: `release_sha`, `frontend`/`backend` sizing (`cpu`, `memory`), alarm thresholds, log retention. The
-  SNS topic ARN is read directly from the `account` remote state, not passed as a variable.
+- `ecs`: `release_sha`, `frontend`/`backend` sizing (`cpu`, `memory`), log retention (core increment); alarm
+  thresholds (observability increment). The SNS topic ARN is read directly from the `account` remote state
+  (observability increment only), not passed as a variable.
 
 ### 7.2 Key outputs per stack
 

--- a/infra/terraform/ecs/.terraform.lock.hcl
+++ b/infra/terraform/ecs/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "~> 6.0, >= 6.19.0, < 7.0.0"
+  hashes = [
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/ecs/README.md
+++ b/infra/terraform/ecs/README.md
@@ -2,35 +2,211 @@
 
 The ECS Fargate application stack. Spec: §4.5. State key: `itassetpulse/demo/ecs.tfstate`.
 
-> Documentation-only until issue **#180** adds the core Terraform configuration; observability wiring lands in
-> **#181**. No `.tf` here yet — do not run Terraform against this directory.
+Delivered in two increments: this core increment (#180) creates the cluster, ALB, routing, secrets, and
+services; the observability increment (#181) adds CloudWatch alarms, a dashboard, and SNS notification
+wiring on top.
 
-## Responsibility
+## What it creates
 
-ECS cluster; **target groups (frontend, backend) and their health check configuration** (owned here, not by
-`modules/ecs-fargate-service` — see below); frontend and backend `modules/ecs-fargate-service` instances
-(`desired_count = 1` each) called with the matching `target_group_arn` and an explicit `depends_on` on the
-listener rule that attaches it; JWT Secrets Manager secret + minimal IAM; ECR image **digest lookup** driven by
-`release_sha`; internet-facing ALB and ALB security group; HTTP listener; default rule → frontend, `/api` +
-`/api/*` rule → backend with the `url-rewrite` transform `^/api/?(.*)$` → `/$1`; CloudWatch log groups, alarms,
-and one dashboard. Reads `foundation`, `data`, and `account` remote state (SNS topic ARN from `account`).
+- `aws_ecs_cluster.this` — a single demo Fargate cluster. No capacity provider, no EC2 capacity, no
+  Container Insights (out of scope for #180).
+- `aws_security_group.alb` + explicit ingress/egress rule resources — ingress TCP 80 from `0.0.0.0/0`;
+  egress TCP `frontend_container_port` and TCP `backend_container_port`, both to `0.0.0.0/0`. The egress
+  rules are **not** scoped to the service modules' own security-group IDs — doing so would only let them be
+  created *after* the service modules, leaving a window where a freshly-started task is unreachable from the
+  ALB. Instead all three rule resources are created before the ALB (`aws_lb.this` has an explicit
+  `depends_on` on all three), and the actual access restriction is enforced on the service side: each
+  service module's own security group only accepts ingress from this ALB security group
+  (`modules/ecs-fargate-service/security_group.tf`, unchanged from #179).
+- `aws_lb.this` — internet-facing ALB in the `foundation` public subnets.
+- **Target groups** (frontend, backend) and their **health check configuration** — owned here, not by
+  `modules/ecs-fargate-service`. See "Target group ownership" below.
+- `aws_lb_listener.http` — HTTP :80, default action forwards to the frontend target group.
+- `aws_lb_listener_rule.backend_api` — `/api` and `/api/*` forward to the backend target group with a
+  `url-rewrite` transform. See "Routing and URL rewrite" below.
+- `aws_secretsmanager_secret.jwt` + `aws_secretsmanager_secret_version.jwt` — a Terraform-generated
+  (`random_password`) `JWT_SECRET`, never a hand-written or tfvars value. Same pattern as `data`'s
+  `mongo_uri` secret: `name_prefix`, `recovery_window_in_days = 0`.
+- `data.aws_ecr_image` digest lookups for both images, driven by `release_sha`. See "Image digest lookup"
+  below.
+- `module.frontend` / `module.backend` — two explicit `modules/ecs-fargate-service` instances (no
+  `for_each`), each with its own execution role.
 
-**Target group ownership.** The target groups live here, not in `modules/ecs-fargate-service`, because AWS
-requires a target group to already be attached to a listener/listener rule before an ECS service can reference
-it in its `load_balancer` block. If the reusable module created both the target group and the ECS service, the
+## What it reads
+
+Only `foundation` and `data` remote state (`data.terraform_remote_state`, first use of this pattern in the
+repo):
+
+- `foundation`: `vpc_id`, `public_subnet_ids`, `backend_ecr_repository_url` + `_arn`,
+  `frontend_ecr_repository_url` + `_arn`.
+- `data`: `mongodb_secret_arn`.
+
+**Not** the `account` remote state. The spec originally described `ecs` as also reading the `account`
+remote state for the SNS topic ARN — that read has no consumer in this increment (no alarms exist yet), so
+it is deferred to #181, which introduces the read together with the alarm wiring that actually uses it
+(`docs/infrastructure-modularization-spec.md` §4.5, §6, §7.1 note this split).
+
+The S3 bucket used for these remote-state reads comes from `var.state_bucket` (not hardcoded — the bucket
+name embeds the AWS account ID, spec §8).
+
+## Target group ownership
+
+The target groups live here, not in `modules/ecs-fargate-service`, because AWS requires a target group to
+already be attached to a listener/listener rule before an ECS service can reference it in its
+`load_balancer` block. If the reusable module created both the target group and the ECS service, the
 module's internal service resource could never be made to depend on a listener rule that the caller builds
-*from* the module's own output — that dependency direction isn't expressible across a module boundary. Keeping
-the target group next to the ALB/listener it is coupled with, and passing its ARN into the module as
+*from* the module's own output — that dependency direction isn't expressible across a module boundary.
+Keeping the target group next to the ALB/listener it is coupled with, and passing its ARN into the module as
 `target_group_arn`, keeps the full `target group → listener/listener rule → ECS service` chain inside one
 `terraform apply` with a normal, expressible `depends_on`.
 
-## Planned inputs
+## Routing and URL rewrite
 
-`project_name`, `environment`, `aws_region`, `release_sha`, frontend/backend sizing (`cpu`, `memory`), alarm
-thresholds, `log_retention_days`. Values from `../environments/demo/ecs.tfvars`.
+The `cloud-static` frontend image (`frontend/nginx.cloud-static.conf.template`) explicitly 404s any `/api`
+request — API routing and prefix-stripping are the ALB's job, not the frontend's, and the backend NestJS app
+has no `/api` prefix of its own (`backend/src/main.ts`, no `setGlobalPrefix`). `aws_lb_listener_rule.backend_api`
+matches `path_pattern` values `["/api", "/api/*"]` (a single rule covers both) and applies a server-side
+`url-rewrite` transform (AWS provider ≥ 6.19, see `versions.tf`):
 
-## Planned outputs
+```
+regex   = "^/api/?(.*)$"
+replace = "/$1"
+```
 
-`alb_dns_name`, `frontend_service_name`, `backend_service_name`, `dashboard_name`.
+| Request path      | Rewritten to (backend sees) |
+|--------------------|------------------------------|
+| `/api`             | `/`                          |
+| `/api/`            | `/`                          |
+| `/api/health`      | `/health`                    |
+| `/api/users`       | `/users`                     |
 
-Implemented in: **#180** (core stack) and **#181** (observability).
+`GET /health` (no `/api` prefix) does **not** match this rule — it falls through to the listener's default
+action, i.e. the **frontend** target group. This is intentional and must be verified explicitly at runtime
+(see below); it is not the same request as `GET /api/health`.
+
+## Image digest lookup
+
+`data.aws_ecr_image` looks up each repository by `image_tag = var.release_sha` (a required, validated
+40-character lowercase Git commit SHA — no short SHA, branch name, or `latest` accepted). If no image with
+that tag has been published (`publish-images.yml` workflow_dispatch), the data source errors and
+`plan`/`apply` fails clearly — there is no fallback tag. The final container image passed into each service
+module is digest-pinned: `<repository-url>@<image-digest>`.
+
+## JWT secret model
+
+`random_password.jwt_secret` (64 chars, `special = true`) → `aws_secretsmanager_secret.jwt` (`name_prefix`,
+`recovery_window_in_days = 0`) → `aws_secretsmanager_secret_version.jwt`. **Trade-off:** the secret value is
+plaintext in Terraform state. No write-only argument is used — the AWS provider supports one, but it is
+disproportionate complexity for a demo project. This is acceptable because the state bucket is encrypted,
+blocks public access, and is reachable only through narrow IAM (spec §9); the value is never output; and
+this is the same pattern `data` already uses for the Mongo URI secret. The backend module's `secrets` map
+gets `MONGO_URI` (from the `data` remote state) and `JWT_SECRET` (created here); the frontend gets no
+secrets.
+
+## Backend health-check grace period
+
+`backend_health_check_grace_period_seconds` defaults to **1200 seconds (20 minutes)**: roughly a 15-minute
+Mongoose connection-retry budget (#178) plus a ~5-minute buffer for the operator to complete the manual
+MongoDB Atlas IP allow-list step (spec §11) and for NestJS bootstrap to finish, before the ECS service could
+otherwise decide to replace the task for failing health checks. A task replacement during this window would
+hand the next task a **new** public IP, forcing the operator to redo the allow-list step. For the same
+reason:
+
+- `wait_for_steady_state = false` on both services (fixed inside `modules/ecs-fargate-service`, not an
+  input) — `apply` does not block waiting for the backend to become healthy.
+- No deployment circuit breaker — automatic rollback would fight the intentional manual window rather than
+  cooperate with it (see the module's own README for the full rationale).
+
+The frontend has no external dependency; its grace period is fixed at `0` directly in `services.tf`, not
+exposed as a variable.
+
+## Two explicit service module instances
+
+`module.frontend` and `module.backend` (no `for_each`). `frontend_desired_count` /
+`backend_desired_count` (both default `1`) control task count per service. Both run in the `foundation`
+public subnets with `assign_public_ip = true` (no NAT, spec Decision E). `module.frontend` has an explicit
+`depends_on` on `aws_lb_listener.http` (its target group is the listener's default action); `module.backend`
+has an explicit `depends_on` on `aws_lb_listener_rule.backend_api` (its target group is attached by that
+rule) — both satisfy the target-group-behind-a-listener ordering requirement described above.
+
+## Manual MongoDB Atlas IP allow-list runbook (spec §11)
+
+There is **no Terraform-managed allow-list** and never a `0.0.0.0/0` entry. Because a Fargate task's public
+IP is dynamic and only known after this stack exists, allow-listing the database deployment IP access list
+is a manual, temporary step:
+
+1. `terraform apply` creates the backend service/task and returns immediately
+   (`wait_for_steady_state = false`), without waiting for target health.
+2. Retrieve the backend task's ENI and current public IP (`aws ecs list-tasks` → `describe-tasks` → ENI →
+   `aws ec2 describe-network-interfaces`).
+3. Create a **temporary** Atlas project IP access-list entry for that public IP (preferably with an
+   expiry/`delete_after_date`).
+4. Wait for the backend target and ECS service to become healthy/stable (`aws ecs wait services-stable`).
+   `backend_health_check_grace_period_seconds` (1200s) covers the Mongoose retry window plus this manual
+   step.
+5. After the demo, remove the entry or let it expire — part of teardown.
+
+**The backend task's public IP must be re-allow-listed after every task replacement or release rollout**,
+because a new task receives a new public IP. This is documented, intentional demo behavior — not automated.
+
+## Inputs / outputs
+
+- Inputs: `project_name`, `environment`, `common_tags`, `aws_region`, `state_bucket`, `release_sha`,
+  `frontend_container_port`, `backend_container_port`, `frontend_cpu`/`frontend_memory`,
+  `backend_cpu`/`backend_memory`, `frontend_desired_count`, `backend_desired_count`,
+  `backend_health_check_grace_period_seconds`, `log_retention_days`. See
+  `../environments/demo/ecs.tfvars.example`. `deployment_min_healthy_percent` (100) and
+  `deployment_max_percent` (200) are fixed in `services.tf`, not exposed as variables.
+- Outputs: `ecs_cluster_name`, `alb_dns_name`, `alb_arn`, `frontend_service_name`, `backend_service_name`,
+  `frontend_target_group_arn`, `backend_target_group_arn`, `jwt_secret_arn`. The JWT secret **value** is
+  never output. (`dashboard_name` will be added by #181.)
+
+Provider version constraints (`versions.tf`): `aws` is pinned `>= 6.19.0, < 7.0.0` (not just `~> 6.0`)
+because the `aws_lb_listener_rule` `transform` block used by `listener.tf` was introduced in 6.19.0; a
+looser constraint would validate/format fine but could resolve an incompatible provider on a stale lockfile.
+`random` is `~> 3.0`, matching `data`. The committed `.terraform.lock.hcl` records the exact resolved
+versions of both.
+
+## Order
+
+```bash
+cd infra/terraform/ecs
+cp backend.hcl.example backend.hcl                                          # fill in the bootstrap-created bucket
+cp ../environments/demo/ecs.tfvars.example ../environments/demo/ecs.tfvars  # fill in real state_bucket / release_sha
+terraform init -backend-config=backend.hcl
+terraform plan  -var-file=../environments/demo/ecs.tfvars -out=tfplan
+terraform apply "tfplan"
+```
+
+Apply/destroy order per spec §13: `bootstrap → account → foundation → data → (publish images) → ecs`.
+
+## Runtime verification (through the ALB only)
+
+The task security groups only accept traffic from the ALB security group — **do not** attempt a direct curl
+against a backend task's public IP; every check below goes through the ALB DNS name.
+
+- `GET /` → frontend `index.html`.
+- `GET /login` (or another SPA route) → frontend `index.html` (nginx `try_files` fallback, not a 404).
+- `GET /api/health` → matches the `/api` listener rule, rewritten to `/health`; backend responds `200` with
+  `Content-Type: application/json`, body `{"status":"ok"}`.
+- `GET /health` (no `/api` prefix) → falls through to the listener's **default action** → frontend
+  `index.html`, **not** the backend health JSON. Verify this explicitly — it is the most likely routing
+  mistake to regress.
+- A real `/api/...` endpoint (e.g. an auth route) returns a backend response.
+- Backend target group health check → `healthy`, only after the Atlas allow-list step above.
+- Task definition digest pinning: `aws ecs describe-task-definition` shows `<repo-url>@sha256:...` for both
+  containers.
+- Second `terraform plan` after apply → `No changes` (idempotency).
+
+## Destroy and preservation
+
+Destroying this stack removes: ECS services, the Terraform-managed task definition revisions, the ECS
+cluster, the ALB, the listener/rule, both target groups, both service security groups (module-owned), both
+CloudWatch log groups (module-owned), and the JWT secret (`recovery_window_in_days = 0` → immediate, so a
+following `apply` never blocks on a pending-deletion secret).
+
+It does **not** touch `foundation`, `data`, `account`, or `bootstrap` state/resources, ECR repositories or
+images, MongoDB Atlas, GitHub variables, or local Docker volumes — those live in separate state files.
+
+Implemented in: **#180** (this file, core stack) — **#181** adds observability (alarms, dashboard, SNS
+wiring, and the `account` remote-state read for the SNS topic ARN).

--- a/infra/terraform/ecs/alb.tf
+++ b/infra/terraform/ecs/alb.tf
@@ -1,0 +1,78 @@
+# ALB security group: ingress TCP 80 from the internet; egress restricted to
+# the frontend/backend container ports, 0.0.0.0/0 (spec §4.5). The two egress
+# rules are NOT scoped to the service modules' own security groups - that
+# would only let the egress rules be created after the module instances,
+# leaving a window where a freshly-started task cannot be reached from the
+# ALB. Instead, all three rule resources (ingress + both egress) are created
+# before the ALB and before the service modules; the actual access
+# restriction happens on the service-module security groups' ingress side
+# (each only accepts traffic from this ALB security group - see
+# modules/ecs-fargate-service/security_group.tf).
+
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb-sg"
+  description = "ALB security group: HTTP ingress from the internet, port-restricted egress to the ECS services."
+  vpc_id      = data.terraform_remote_state.foundation.outputs.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-alb-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTP from the internet."
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+
+  tags = local.common_tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_to_frontend" {
+  security_group_id = aws_security_group.alb.id
+  description       = "To the frontend service's container port."
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = var.frontend_container_port
+  to_port           = var.frontend_container_port
+  ip_protocol       = "tcp"
+
+  tags = local.common_tags
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_to_backend" {
+  security_group_id = aws_security_group.alb.id
+  description       = "To the backend service's container port."
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = var.backend_container_port
+  to_port           = var.backend_container_port
+  ip_protocol       = "tcp"
+
+  tags = local.common_tags
+}
+
+resource "aws_lb" "this" {
+  name               = "${local.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  ip_address_type    = "ipv4"
+  subnets            = data.terraform_remote_state.foundation.outputs.public_subnet_ids
+  security_groups    = [aws_security_group.alb.id]
+
+  enable_deletion_protection = false
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-alb"
+  })
+
+  # aws_lb only implicitly depends on the security group resource itself (via
+  # security_groups), not on these separate rule resources. Without this
+  # explicit depends_on, Terraform could create the ALB before its security
+  # group has any ingress/egress rules attached.
+  depends_on = [
+    aws_vpc_security_group_ingress_rule.alb_http,
+    aws_vpc_security_group_egress_rule.alb_to_frontend,
+    aws_vpc_security_group_egress_rule.alb_to_backend,
+  ]
+}

--- a/infra/terraform/ecs/backend.tf
+++ b/infra/terraform/ecs/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  # Partial configuration: real values come from backend.hcl (git-ignored),
+  # supplied via `terraform init -backend-config=backend.hcl`.
+  backend "s3" {}
+}

--- a/infra/terraform/ecs/ecr_images.tf
+++ b/infra/terraform/ecs/ecr_images.tf
@@ -1,0 +1,18 @@
+# Digest lookup by release_sha (spec §10.2). If no image with this tag has
+# been published, the data source errors and plan/apply fails clearly - there
+# is no fallback tag (not "latest", not a mutable branch tag).
+
+data "aws_ecr_image" "backend" {
+  repository_name = local.backend_ecr_repository_name
+  image_tag       = var.release_sha
+}
+
+data "aws_ecr_image" "frontend" {
+  repository_name = local.frontend_ecr_repository_name
+  image_tag       = var.release_sha
+}
+
+locals {
+  backend_image_uri  = "${data.terraform_remote_state.foundation.outputs.backend_ecr_repository_url}@${data.aws_ecr_image.backend.image_digest}"
+  frontend_image_uri = "${data.terraform_remote_state.foundation.outputs.frontend_ecr_repository_url}@${data.aws_ecr_image.frontend.image_digest}"
+}

--- a/infra/terraform/ecs/ecs_cluster.tf
+++ b/infra/terraform/ecs/ecs_cluster.tf
@@ -1,0 +1,10 @@
+# Demo Fargate-only cluster: no capacity provider, no EC2 capacity, no
+# Container Insights (observability is #181's scope, not this issue's).
+
+resource "aws_ecs_cluster" "this" {
+  name = "${local.name_prefix}-cluster"
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-cluster"
+  })
+}

--- a/infra/terraform/ecs/listener.tf
+++ b/infra/terraform/ecs/listener.tf
@@ -1,0 +1,49 @@
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.frontend.arn
+  }
+
+  tags = local.common_tags
+}
+
+# Routes /api and /api/* to the backend target group. The url-rewrite
+# transform strips the /api prefix server-side before the request reaches the
+# backend (spec §3.1), so the backend keeps its existing root-relative routes
+# and no app.setGlobalPrefix('api') change is needed:
+#   /api            -> /
+#   /api/           -> /
+#   /api/health     -> /health
+#   /api/users      -> /users
+resource "aws_lb_listener_rule" "backend_api" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/api", "/api/*"]
+    }
+  }
+
+  transform {
+    type = "url-rewrite"
+
+    url_rewrite_config {
+      rewrite {
+        regex   = "^/api/?(.*)$"
+        replace = "/$1"
+      }
+    }
+  }
+
+  tags = local.common_tags
+}

--- a/infra/terraform/ecs/locals.tf
+++ b/infra/terraform/ecs/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = merge(var.common_tags, {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Purpose     = "ecs"
+  })
+
+  # aws_ecr_image requires a bare repository_name, not the ARN/URL foundation
+  # exports - the repository name is the segment after "repository/" in the ARN.
+  backend_ecr_repository_name  = split("/", data.terraform_remote_state.foundation.outputs.backend_ecr_repository_arn)[1]
+  frontend_ecr_repository_name = split("/", data.terraform_remote_state.foundation.outputs.frontend_ecr_repository_arn)[1]
+}

--- a/infra/terraform/ecs/outputs.tf
+++ b/infra/terraform/ecs/outputs.tf
@@ -1,0 +1,39 @@
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster."
+  value       = aws_ecs_cluster.this.name
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer."
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer."
+  value       = aws_lb.this.arn
+}
+
+output "frontend_service_name" {
+  description = "Name of the frontend ECS service."
+  value       = module.frontend.service_name
+}
+
+output "backend_service_name" {
+  description = "Name of the backend ECS service."
+  value       = module.backend.service_name
+}
+
+output "frontend_target_group_arn" {
+  description = "ARN of the frontend ALB target group."
+  value       = aws_lb_target_group.frontend.arn
+}
+
+output "backend_target_group_arn" {
+  description = "ARN of the backend ALB target group."
+  value       = aws_lb_target_group.backend.arn
+}
+
+output "jwt_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding JWT_SECRET. Never the secret value."
+  value       = aws_secretsmanager_secret.jwt.arn
+}

--- a/infra/terraform/ecs/providers.tf
+++ b/infra/terraform/ecs/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+# The random provider has no configurable arguments; no provider block needed.

--- a/infra/terraform/ecs/remote_state.tf
+++ b/infra/terraform/ecs/remote_state.tf
@@ -1,0 +1,24 @@
+# First stack in this repo to read another stack's remote state. Only
+# foundation and data are read - the account remote state (SNS topic ARN) is
+# introduced by #181 together with the alarms that actually consume it; this
+# core increment has no use for it (spec §4.5, issue #180).
+
+data "terraform_remote_state" "foundation" {
+  backend = "s3"
+
+  config = {
+    bucket = var.state_bucket
+    key    = "itassetpulse/demo/foundation.tfstate"
+    region = var.aws_region
+  }
+}
+
+data "terraform_remote_state" "data" {
+  backend = "s3"
+
+  config = {
+    bucket = var.state_bucket
+    key    = "itassetpulse/demo/data.tfstate"
+    region = var.aws_region
+  }
+}

--- a/infra/terraform/ecs/secrets.tf
+++ b/infra/terraform/ecs/secrets.tf
@@ -1,0 +1,22 @@
+# JWT_SECRET: Terraform-generated, never a hand-written, version-controlled
+# value (spec §9). Same pattern as data/secrets.tf's mongo_uri secret.
+
+resource "random_password" "jwt_secret" {
+  length  = 64
+  special = true
+}
+
+resource "aws_secretsmanager_secret" "jwt" {
+  name_prefix = "${local.name_prefix}-jwt-"
+
+  # Ephemeral apply/destroy cycle (spec §9): immediate deletion so a
+  # short-lived name is never blocked by a pending-deletion secret.
+  recovery_window_in_days = 0
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "jwt" {
+  secret_id     = aws_secretsmanager_secret.jwt.id
+  secret_string = random_password.jwt_secret.result
+}

--- a/infra/terraform/ecs/services.tf
+++ b/infra/terraform/ecs/services.tf
@@ -1,0 +1,78 @@
+# Two explicit module blocks (no for_each) - spec §5.3.
+
+module "frontend" {
+  source = "../modules/ecs-fargate-service"
+
+  name         = "frontend"
+  cluster_arn  = aws_ecs_cluster.this.arn
+  project_name = var.project_name
+  environment  = var.environment
+  common_tags  = local.common_tags
+
+  container_image = local.frontend_image_uri
+  container_port  = var.frontend_container_port
+  desired_count   = var.frontend_desired_count
+  cpu             = var.frontend_cpu
+  memory          = var.frontend_memory
+
+  public_subnet_ids     = data.terraform_remote_state.foundation.outputs.public_subnet_ids
+  assign_public_ip      = true
+  alb_security_group_id = aws_security_group.alb.id
+  vpc_id                = data.terraform_remote_state.foundation.outputs.vpc_id
+
+  environment_variables = {}
+  secrets               = {}
+
+  target_group_arn = aws_lb_target_group.frontend.arn
+
+  # No external dependency (static SPA) - no manual runbook step to wait out.
+  health_check_grace_period_seconds = 0
+  deployment_min_healthy_percent    = 100
+  deployment_max_percent            = 200
+  log_retention_days                = var.log_retention_days
+
+  # The frontend target group must already be the listener's default action
+  # before the service can register with it.
+  depends_on = [aws_lb_listener.http]
+}
+
+module "backend" {
+  source = "../modules/ecs-fargate-service"
+
+  name         = "backend"
+  cluster_arn  = aws_ecs_cluster.this.arn
+  project_name = var.project_name
+  environment  = var.environment
+  common_tags  = local.common_tags
+
+  container_image = local.backend_image_uri
+  container_port  = var.backend_container_port
+  desired_count   = var.backend_desired_count
+  cpu             = var.backend_cpu
+  memory          = var.backend_memory
+
+  public_subnet_ids     = data.terraform_remote_state.foundation.outputs.public_subnet_ids
+  assign_public_ip      = true
+  alb_security_group_id = aws_security_group.alb.id
+  vpc_id                = data.terraform_remote_state.foundation.outputs.vpc_id
+
+  environment_variables = {}
+  secrets = {
+    MONGO_URI  = data.terraform_remote_state.data.outputs.mongodb_secret_arn
+    JWT_SECRET = aws_secretsmanager_secret.jwt.arn
+  }
+
+  target_group_arn = aws_lb_target_group.backend.arn
+
+  # Sized for the Mongoose retry budget plus the manual Atlas allow-list
+  # window (see variables.tf / README).
+  health_check_grace_period_seconds = var.backend_health_check_grace_period_seconds
+  deployment_min_healthy_percent    = 100
+  deployment_max_percent            = 200
+  log_retention_days                = var.log_retention_days
+
+  # The backend target group must already be attached to the /api listener
+  # rule before the service can register with it (target-group-behind-a-
+  # listener requirement, see README "Target group ownership").
+  depends_on = [aws_lb_listener_rule.backend_api]
+}

--- a/infra/terraform/ecs/target_groups.tf
+++ b/infra/terraform/ecs/target_groups.tf
@@ -1,0 +1,46 @@
+# Target groups live here, not in modules/ecs-fargate-service: a target group
+# must already be attached to a listener/listener rule before an ECS service
+# can reference it, so it has to be created next to the ALB/listener it is
+# coupled with (see README "Target group ownership").
+
+resource "aws_lb_target_group" "frontend" {
+  name        = "${local.name_prefix}-frontend-tg"
+  port        = var.frontend_container_port
+  protocol    = "HTTP"
+  vpc_id      = data.terraform_remote_state.foundation.outputs.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-frontend-tg"
+  })
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = "${local.name_prefix}-backend-tg"
+  port        = var.backend_container_port
+  protocol    = "HTTP"
+  vpc_id      = data.terraform_remote_state.foundation.outputs.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-backend-tg"
+  })
+}

--- a/infra/terraform/ecs/variables.tf
+++ b/infra/terraform/ecs/variables.tf
@@ -1,0 +1,126 @@
+variable "project_name" {
+  description = "Project name used to build resource names and tags."
+  type        = string
+  default     = "itassetpulse"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{0,32}[a-z0-9])?$", var.project_name))
+    error_message = "project_name must be 1-34 characters, lowercase letters, digits and hyphens only, and start and end with a letter or digit."
+  }
+}
+
+variable "environment" {
+  description = "Environment name used to build resource names, tags, and the remote-state key (e.g. \"demo\")."
+  type        = string
+  default     = "demo"
+}
+
+variable "common_tags" {
+  description = "Additional tags merged into every resource created by this stack."
+  type        = map(string)
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region where the ECS stack and its remote-state reads are located."
+  type        = string
+  default     = "eu-north-1"
+}
+
+variable "state_bucket" {
+  description = "Name of the S3 bucket created by the bootstrap stack, used to read the foundation and data stacks' remote state. Contains the AWS account ID, so it is never hardcoded or defaulted here (spec §8)."
+  type        = string
+}
+
+variable "release_sha" {
+  description = "Full Git commit SHA of the backend/frontend images published by publish-images.yml. Used as the ECR image_tag for the digest lookup; no fallback tag is accepted."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{40}$", var.release_sha))
+    error_message = "release_sha must be a full 40-character lowercase hexadecimal Git commit SHA (not a short SHA, branch name, or \"latest\")."
+  }
+}
+
+variable "frontend_container_port" {
+  description = "Port the frontend container listens on (nginx, cloud-static image)."
+  type        = number
+  default     = 80
+}
+
+variable "backend_container_port" {
+  description = "Port the backend container listens on (NestJS, backend/src/main.ts)."
+  type        = number
+  default     = 3000
+}
+
+variable "frontend_cpu" {
+  description = "Fargate CPU units for the frontend task."
+  type        = number
+  default     = 256
+}
+
+variable "frontend_memory" {
+  description = "Fargate memory (MiB) for the frontend task."
+  type        = number
+  default     = 512
+}
+
+variable "backend_cpu" {
+  description = "Fargate CPU units for the backend task."
+  type        = number
+  default     = 256
+}
+
+variable "backend_memory" {
+  description = "Fargate memory (MiB) for the backend task."
+  type        = number
+  default     = 512
+}
+
+variable "frontend_desired_count" {
+  description = "Desired number of running frontend tasks."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.frontend_desired_count >= 0 && floor(var.frontend_desired_count) == var.frontend_desired_count
+    error_message = "frontend_desired_count must be a non-negative whole number."
+  }
+}
+
+variable "backend_desired_count" {
+  description = "Desired number of running backend tasks."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.backend_desired_count >= 0 && floor(var.backend_desired_count) == var.backend_desired_count
+    error_message = "backend_desired_count must be a non-negative whole number."
+  }
+}
+
+variable "backend_health_check_grace_period_seconds" {
+  description = "Seconds the backend ECS service ignores failing ALB health checks after a task starts. Sized for a ~15-minute Mongoose connection-retry budget (#178) plus a ~5-minute operator buffer to complete the manual MongoDB Atlas IP allow-list step (spec §11) before the task could otherwise be replaced (which would hand the next task a new public IP). The frontend has no such external dependency; its grace period is fixed at 0 in services.tf, not exposed as a variable."
+  type        = number
+  default     = 1200
+
+  validation {
+    condition     = var.backend_health_check_grace_period_seconds >= 0 && floor(var.backend_health_check_grace_period_seconds) == var.backend_health_check_grace_period_seconds
+    error_message = "backend_health_check_grace_period_seconds must be a non-negative whole number."
+  }
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention period in days for both services' log groups."
+  type        = number
+  default     = 7
+
+  validation {
+    condition = contains(
+      [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.log_retention_days
+    )
+    error_message = "log_retention_days must be one of the values CloudWatch Logs accepts for retention_in_days (e.g. 1, 3, 5, 7, 14, 30, 60, 90, ...)."
+  }
+}

--- a/infra/terraform/ecs/versions.tf
+++ b/infra/terraform/ecs/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # >= 6.19.0: the aws_lb_listener_rule `transform` block (url-rewrite),
+      # used by listener.tf to strip the /api prefix, was introduced in this
+      # provider version. The constraint must express this minimum itself -
+      # relying on the committed lockfile alone would let a stale lockfile
+      # silently resolve to an older, incompatible provider.
+      version = ">= 6.19.0, < 7.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/infra/terraform/environments/demo/ecs.tfvars.example
+++ b/infra/terraform/environments/demo/ecs.tfvars.example
@@ -1,10 +1,14 @@
-# ecs (demo) — copy to ecs.tfvars (git-ignored) and set values. Implemented in #180 / #181.
+# ecs (demo) — copy to ecs.tfvars (git-ignored) and set values. Implemented in #180.
 project_name = "itassetpulse"
 environment  = "demo"
 aws_region   = "eu-north-1" # example — confirm per spec §16
 
+# Name of the bucket created by the bootstrap stack (contains the AWS account
+# ID; never hardcoded in .tf, see variables.tf):
+state_bucket = "<your-terraform-state-bucket>"
+
 # Full Git commit SHA of the images published by publish-images.yml (spec §10.2):
-release_sha  = "<git-commit-sha>"
+release_sha = "<git-commit-sha>"
 
 # Fargate sizing (examples)
 frontend_cpu    = 256
@@ -12,7 +16,7 @@ frontend_memory = 512
 backend_cpu     = 256
 backend_memory  = 512
 
-log_retention_days = 7
+frontend_desired_count = 1
+backend_desired_count  = 1
 
-# Alarm thresholds (examples)
-alb_5xx_threshold = 5
+log_retention_days = 7


### PR DESCRIPTION
Refs #180

## Summary

- új ECS root stack (`infra/terraform/ecs`);
- ECS Fargate cluster;
- internet-facing ALB;
- frontend és backend target group;
- HTTP listener és `/api`, `/api/*` routing;
- ALB URL rewrite az `/api` prefix eltávolítására;
- két explicit reusable ECS service module instance (`modules/ecs-fargate-service`, #179);
- digest-pinned ECR image lookup teljes release SHA alapján;
- JWT Secrets Manager secret;
- foundation és data remote state kapcsolatok;
- nincs account remote state vagy SNS wiring (ez #181 feladata);
- új AWS-mentes ECS Terraform CI validation job.

## Routing

- `/` és SPA route-ok → frontend;
- `/api` és `/api/*` → backend;
- `/api/health` rewrite után `/health`;
- `/health` prefix nélkül → frontend default action.

## Security and secrets

- ALB SG csak HTTP 80 ingress;
- portkorlátozott ALB egress;
- service SG-k csak az ALB SG-ből engednek ingress forgalmat;
- nincs hardcode-olt JWT secret;
- MongoDB és JWT értékek Secrets Managerből kerülnek a backend taskba;
- nincs secretérték output.

## Validation

- `terraform fmt`;
- `terraform init -backend=false -lockfile=readonly`;
- `terraform validate`;
- `git diff --check`;
- nincs AWS plan/apply ebben a PR-körben.

## Runtime pending

A következők a merge után, külön runtime-verifikációs körben történnek:

- valós backend init;
- Terraform plan review;
- Terraform apply;
- backend task public IP lekérése;
- Atlas allow-list;
- ALB és ECS runtime teszt;
- image digest ellenőrzés;
- idempotens második plan;
- csak ezután zárható #180.
