### PR TITLE
fix: ignore Terraform plan artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,10 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
+# Terraform plan files may contain sensitive values
+*.tfplan
+*.tfplan.*
+
 # Terraform backend local config
 backend.hcl
 


### PR DESCRIPTION
Refs #180

## Summary

- a Terraform saved plan (`.tfplan`) bináris fájl érzékeny értékeket tartalmazhat (pl. generált jelszót, connection stringet) plaintext formában, még akkor is, ha a CLI-kimenet ezeket `(sensitive value)`-ként elrejti;
- a korábbi README-feltételezés ellenére (`data/README.md`: "tfplan is git-ignored and stays local only") a plan fájlok ténylegesen **nem voltak** gitignore-olva a `.gitignore`-ban;
- az új minták (`*.tfplan`, `*.tfplan.*`) lefedik a `.tfplan` fájlokat és az abból származtatott fájlokat (pl. `.tfplan.json`), anélkül hogy normál Terraform source vagy `.tfvars.example` fájlokat kizárnának;
- nincs Terraform/AWS/Atlas runtime művelet ebben a PR-ben — kizárólag a `.gitignore` változott.
