### PR TITLE
fix(infra): use valid security rule descriptions

### DIFF
--- a/infra/terraform/ecs/alb.tf
+++ b/infra/terraform/ecs/alb.tf
@@ -32,7 +32,7 @@ resource "aws_vpc_security_group_ingress_rule" "alb_http" {
 
 resource "aws_vpc_security_group_egress_rule" "alb_to_frontend" {
   security_group_id = aws_security_group.alb.id
-  description       = "To the frontend service's container port."
+  description       = "To the frontend service container port."
   cidr_ipv4         = "0.0.0.0/0"
   from_port         = var.frontend_container_port
   to_port           = var.frontend_container_port
@@ -43,7 +43,7 @@ resource "aws_vpc_security_group_egress_rule" "alb_to_frontend" {
 
 resource "aws_vpc_security_group_egress_rule" "alb_to_backend" {
   security_group_id = aws_security_group.alb.id
-  description       = "To the backend service's container port."
+  description       = "To the backend service container port."
   cidr_ipv4         = "0.0.0.0/0"
   from_port         = var.backend_container_port
   to_port           = var.backend_container_port

--- a/infra/terraform/modules/ecs-fargate-service/security_group.tf
+++ b/infra/terraform/modules/ecs-fargate-service/security_group.tf
@@ -24,7 +24,7 @@ resource "aws_vpc_security_group_ingress_rule" "from_alb" {
 # destination egress is a deferred hardening item, not v1 scope.
 resource "aws_vpc_security_group_egress_rule" "all" {
   security_group_id = aws_security_group.this.id
-  description       = "Allow-all egress (ephemeral demo; see spec §5.3)"
+  description       = "Allow-all egress (ephemeral demo; see spec section 5.3)"
 
   cidr_ipv4   = "0.0.0.0/0"
   ip_protocol = "-1"


### PR DESCRIPTION
Refs #180

## Problem

The first ECS runtime deployment exposed two AWS EC2 validation failures in security-group rule descriptions:

- apostrophe characters in the ALB egress rule descriptions;
- a section sign or another unsupported character in the reusable service module description.

AWS rejected these descriptions before the dependent resources could be created.

## Fix

- replace the invalid description values with short AWS-compatible ASCII text;
- preserve all ports, protocols, CIDRs, source security groups and dependencies;
- make no behavioral networking or IAM changes.

## Runtime context

- the initial apply completed after the local corrections;
- the ECS stack currently has 30 managed resources;
- both services and target groups are healthy;
- ALB routing and URL rewriting were verified;
- the current infrastructure matches the corrected local configuration;
- issue #180 remains open until this PR is merged and a clean-main Terraform plan reports No changes.

## Validation

- Terraform format checks;
- ECS root-stack validation;
- reusable module validation;
- git diff check;
- no Terraform plan/apply/destroy in this PR preparation round;
- no AWS or MongoDB Atlas mutation.