### PR TITLE
refactor(infra): migrate Terraform state to HCP workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ The earlier AWS deployment of this project is preserved in the baseline tag `inf
 
 **Current status:**
 
-- The current Terraform remote-state backend exists in AWS S3. Its retirement is tracked by issue #209.
+- **HCP Terraform is the active Terraform state backend** for `account`, `foundation`, `data` and `ecs` (migrated in #203). The former AWS S3 backend is a retained historical recovery copy only; its retirement together with the `bootstrap` stack is tracked by issue #209.
 - The demo infrastructure (foundation, data and ECS resources) is currently **not provisioned**; ECS Fargate + ALB is the implemented Terraform target architecture, not a running environment.
 - The AWS infrastructure is currently being reviewed and redesigned.
-- The HCP Terraform project and four Local execution workspaces were created under #202, while Terraform state migration remains tracked by #203.
+- The HCP Terraform project and four Local execution workspaces were created under #202; the state migration onto them is #203. A pre-existing AWS drift on the `account` OIDC provider was found during migration and is tracked for resolution by #207.
 - A reusable local Jenkins controller is implemented in the separate `AldrionDev/local-jenkins-platform` repository. ITAssetPulse-specific pipelines are not implemented yet.
 - The current architecture and responsibility boundary are documented in [`docs/infrastructure-hcp-jenkins-spec.md`](docs/infrastructure-hcp-jenkins-spec.md) and [`ci/jenkins/README.md`](ci/jenkins/README.md).
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -124,8 +124,10 @@ no effect on a running environment.
 - The demo infrastructure is **currently not provisioned**: the `foundation`, `data` and `ecs` resources do not
   exist in AWS. ECS Fargate + ALB is the implemented Terraform target architecture, not a running environment.
 - The future full rebuild of the demo environment is tracked by **#200**.
-- The HCP Terraform project and four Local execution workspaces were created under #202. State migration from
-  the current S3 backend remains owned by #203.
+- The HCP Terraform project and four Local execution workspaces were created under #202, and the state
+  migration onto them (#203) is complete: HCP Terraform is now the active state backend. `terraform init
+  -backend=false` skips HCP Terraform initialization the same way it skips a backend, so CI remains free of
+  both AWS and HCP Terraform credentials.
 - The reusable local Jenkins controller is implemented in the separate
   `AldrionDev/local-jenkins-platform` repository. ITAssetPulse-specific ECR publishing and Terraform execution
   pipelines remain owned by #206 and #208.
@@ -138,4 +140,4 @@ no effect on a running environment.
 - HCP Terraform and local Jenkins architecture and implementation status: [`infrastructure-hcp-jenkins-spec.md`](./infrastructure-hcp-jenkins-spec.md)
 - ITAssetPulse Jenkins integration and pipeline ownership: [`../ci/jenkins/README.md`](../ci/jenkins/README.md)
 - Apply / demo / destroy procedure: [`runbooks/ephemeral-demo-lifecycle.md`](./runbooks/ephemeral-demo-lifecycle.md)
-- Terraform stack layout, state keys and CI job mapping: [`../infra/terraform/README.md`](../infra/terraform/README.md)
+- Terraform stack layout, HCP workspace mapping and CI job mapping: [`../infra/terraform/README.md`](../infra/terraform/README.md)

--- a/docs/infrastructure-hcp-jenkins-spec.md
+++ b/docs/infrastructure-hcp-jenkins-spec.md
@@ -44,9 +44,11 @@ architecture, which remains specified in
 
 **Status: CURRENT**
 
-- Terraform remote state for `account`, `foundation`, `data` and `ecs` lives in an AWS S3 bucket created and
-  owned by the `bootstrap` stack (`backend "s3" {}` in each root's `backend.tf`).
-- `bootstrap` itself uses local state and is the sole owner of the state bucket and its locking mechanism.
+- Terraform remote state for `account`, `foundation`, `data` and `ecs` lives in HCP Terraform (migrated by
+  #203; `cloud {}` in each root's `backend.tf`). The former AWS S3 bucket created and owned by the
+  `bootstrap` stack is a retained historical recovery copy only, no longer read or written.
+- `bootstrap` itself uses local state and remains the sole owner of the (now unused) state bucket and its
+  locking mechanism until #209 retires it.
 - GitHub Actions CI (`ci.yml`) is AWS-credential-free: it runs lint, test, build and `terraform fmt -check` /
   `terraform init -backend=false` / `terraform validate` only, with the backend disabled in every job.
 - `publish-images.yml` is the only workflow that authenticates to AWS. It is explicitly **transitional**: it
@@ -54,7 +56,7 @@ architecture, which remains specified in
   and ownership can change outside this repository at any time.
 - ECS Fargate + ALB is the **implemented Terraform target architecture** — the code exists — but the
   `foundation`, `data` and `ecs` demo resources are **currently not provisioned** in AWS.
-- The HCP Terraform project and four Local execution workspaces were created under #202. Terraform state migration remains owned by #203.
+- The HCP Terraform project and four Local execution workspaces were created under #202. Terraform state migration onto them (#203) is complete: HCP Terraform is now the active backend for `account`, `foundation`, `data` and `ecs`.
 - The reusable local Jenkins controller is implemented in the separate `AldrionDev/local-jenkins-platform` repository. ITAssetPulse-specific integration documentation is implemented under #204.
 - No ITAssetPulse Jenkins pipeline has been implemented yet; image publishing remains #206 and manually approved Terraform execution remains #208.
 
@@ -112,10 +114,10 @@ consequences for the target design:
 
 ## 6. HCP Terraform responsibilities
 
-**Status: CURRENT (project and workspaces) / PLANNED (state migration and Jenkins use)**
+**Status: CURRENT**
 
-- Will store the Terraform state and full state history for every active remote-state root (`account`,
-  `foundation`, `data`, `ecs`) after #203 replaces the AWS S3 backend.
+- Stores the Terraform state and full state history for every active remote-state root (`account`,
+  `foundation`, `data`, `ecs`) — #203 migrated them off the AWS S3 backend.
 - Does **not** execute Terraform runs. Every workspace uses Local execution mode (§7).
 - Provides the authentication surface (`terraform login` / `TF_TOKEN_app_terraform_io`) used locally and,
   once #208 lands, from Jenkins.
@@ -125,7 +127,7 @@ consequences for the target design:
 
 ## 7. Local execution mode
 
-**Status: CURRENT (workspace mode) / PLANNED (state migration and Jenkins execution)**
+**Status: CURRENT (workspace mode, state migration) / PLANNED (Jenkins execution)**
 
 Every HCP Terraform workspace ITAssetPulse uses runs in **Local execution mode**, not Remote or Agent
 execution:
@@ -158,21 +160,25 @@ workspace is created — the `bootstrap` stack is not migrated (§9).
 
 ## 9. Terraform root and state ownership
 
-**Status: PLANNED (target) / CURRENT (starting point)**
+**Status: CURRENT**
 
-| Root         | Current state            | Target state              | Notes                                                                                                         |
-| ------------ | ------------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `bootstrap`  | Local state, 5 resources | **Not migrated**          | Retired by #209 once HCP Terraform is proven; its only responsibility (the S3 state bucket) becomes obsolete. |
-| `account`    | S3, 6 managed resources  | `itassetpulse-account`    | The **only** currently non-empty remote state — the only root requiring a real state migration (#203).        |
-| `foundation` | S3, empty (0 resources)  | `itassetpulse-foundation` | Clean re-init against the new workspace; nothing to move.                                                     |
-| `data`       | S3, empty (0 resources)  | `itassetpulse-data`       | Clean re-init against the new workspace; nothing to move.                                                     |
-| `ecs`        | S3, empty (0 resources)  | `itassetpulse-ecs`        | Clean re-init against the new workspace; nothing to move.                                                     |
+| Root         | Former state              | Current state              | Notes                                                                                                         |
+| ------------ | -------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `bootstrap`  | Local state, 5 resources   | **Not migrated**           | Retired by #209 once HCP Terraform is proven; its only responsibility (the S3 state bucket) becomes obsolete. |
+| `account`    | S3, **7** managed resources | `itassetpulse-account`     | Migrated in #203. The only root with a real state migration; all seven managed resources preserved unchanged. A pre-existing AWS drift on the OIDC provider resource was found and deferred to #207. |
+| `foundation` | S3, empty (0 resources)    | `itassetpulse-foundation`  | Cleanly re-initialized in #203; no state snapshot exists yet — nothing was there to move.                     |
+| `data`       | S3, empty (0 resources)    | `itassetpulse-data`        | Cleanly re-initialized in #203; no state snapshot exists yet — nothing was there to move.                     |
+| `ecs`        | S3, empty (0 resources)    | `itassetpulse-ecs`         | Cleanly re-initialized in #203; no state snapshot exists yet — nothing was there to move.                     |
+
+> **Historical correction.** This table previously read "6 managed resources" for `account`. That figure was
+> an unverified planning assumption inherited from #201. #203's Gate 4 preflight read the real state and
+> found **seven** — the extra address is `aws_iam_openid_connect_provider.github_actions[0]`, a legitimate
+> managed member of the state that #203 preserved unchanged. Its removal belongs to #207, not #203.
 
 `ecs` reads outputs from `account` (SNS topic ARN, observability increment), `foundation` (VPC/ECR outputs)
 and `data` (Secrets Manager secret ARN) via `terraform_remote_state`, matching the dependency graph in
 [`infrastructure-modularization-spec.md` §6](./infrastructure-modularization-spec.md#6-state-keys-and-dependency-graph).
-Under HCP Terraform this becomes a `backend = "remote"` read against the corresponding HCP workspace instead
-of an S3 key.
+Since #203 this is a `backend = "remote"` read against the corresponding HCP workspace instead of an S3 key.
 
 ---
 
@@ -478,9 +484,13 @@ unfinished work remains owned by the referenced follow-up issues.
 
 **Status: CURRENT**
 
-At the completion of issue #204:
+At the completion of issue #203:
 
-- Terraform state for `account`, `foundation`, `data` and `ecs` remains in the AWS S3 backend owned by `bootstrap`. Migration to HCP Terraform remains owned by #203.
+- Terraform state for `account`, `foundation`, `data` and `ecs` is now in HCP Terraform. #203 migrated the
+  `account` state (seven managed resources, preserved unchanged) and cleanly initialized the three empty
+  roots. The former AWS S3 backend owned by `bootstrap` is a retained historical recovery copy only, not
+  read or written after migration; its retirement together with `bootstrap` remains owned by #209. A
+  pre-existing AWS drift on the `account` OIDC provider was found during migration and deferred to #207.
 - The HCP Terraform project and four CLI-driven Local execution workspaces were created and verified under #202:
   - `itassetpulse-account`;
   - `itassetpulse-foundation`;

--- a/docs/infrastructure-modularization-spec.md
+++ b/docs/infrastructure-modularization-spec.md
@@ -121,10 +121,13 @@ Five active stacks (`bootstrap`, `account`, `foundation`, `data`, `ecs`) plus a 
 
 ### 4.1 `bootstrap` — local state, one-time, persistent
 
-> **Superseded by the planned target model.** The AWS S3 state backend described in this section is planned to
-> be replaced by HCP Terraform state storage, and `bootstrap` is planned to be retired rather than migrated.
-> See [`infrastructure-hcp-jenkins-spec.md`](./infrastructure-hcp-jenkins-spec.md) for the target model. This
-> section remains accurate for the **current** implementation.
+> **Superseded by the executed target model.** #203 replaced the AWS S3 state backend described in this
+> section with HCP Terraform state storage for `account`, `foundation`, `data` and `ecs`. `bootstrap` itself
+> was **not** migrated — it keeps local state and is retired outright by #209, once its only remaining
+> responsibility (the now-unused S3 state bucket) is no longer needed. See
+> [`infrastructure-hcp-jenkins-spec.md`](./infrastructure-hcp-jenkins-spec.md) and
+> [`docs/runbooks/hcp-terraform-workspaces.md`](./runbooks/hcp-terraform-workspaces.md) for the executed
+> model. This section is kept only as the **historical** description of how the S3 backend worked.
 
 Creates **only** the Terraform remote-state infrastructure:
 
@@ -335,18 +338,17 @@ lookup, release-SHA selection, JWT secret, alarms, dashboard, SNS wiring) stays 
 
 ## 6. State keys and dependency graph
 
-> **Superseded by the planned target model.** The S3 state keys below are planned to be replaced by HCP
-> Terraform workspaces (`itassetpulse-account`, `itassetpulse-foundation`, `itassetpulse-data`,
-> `itassetpulse-ecs`), one per remote-state root. See
-> [`infrastructure-hcp-jenkins-spec.md`](./infrastructure-hcp-jenkins-spec.md). The dependency graph itself
-> (which stack reads which other stack's outputs) is unaffected by the backend change and remains accurate.
-
-State bucket and locking are created by `bootstrap` (local state). All other stacks use the S3 backend with a
-distinct key configured through a per-stack `backend.hcl`.
+> **Superseded by the executed target model.** #203 replaced the S3 state keys below with HCP Terraform
+> workspaces (`itassetpulse-account`, `itassetpulse-foundation`, `itassetpulse-data`, `itassetpulse-ecs`),
+> one per remote-state root — see
+> [`docs/runbooks/hcp-terraform-workspaces.md`](./runbooks/hcp-terraform-workspaces.md) for the executed
+> migration record. The dependency graph itself (which stack reads which other stack's outputs) is
+> unaffected by the backend change and remains accurate. The S3 keys below are kept only as a **historical**
+> record of the pre-#203 backend.
 
 ```
-State keys:
-  bootstrap                          -> local state
+Historical S3 state keys (superseded by #203):
+  bootstrap                          -> local state (unchanged; bootstrap was not migrated)
   itassetpulse/global/account.tfstate
   itassetpulse/demo/foundation.tfstate
   itassetpulse/demo/data.tfstate
@@ -379,8 +381,10 @@ state, not copied from bootstrap.
 
 ## 7. Variables and outputs
 
-Repository contains only `*.tfvars.example` and `backend.hcl.example`. Real `*.tfvars`, `backend.hcl`, state
-files, and `.terraform/` remain git-ignored and are never committed.
+Repository contains only `*.tfvars.example` files. Real `*.tfvars`, state files, and `.terraform/` remain
+git-ignored and are never committed. `backend.hcl` / `backend.hcl.example` no longer exist for `account`,
+`foundation`, `data` and `ecs` — since #203 their backend configuration is a complete `cloud {}` block
+committed in `backend.tf`, needing no local override file.
 
 Environment layout:
 

--- a/docs/runbooks/ephemeral-demo-lifecycle.md
+++ b/docs/runbooks/ephemeral-demo-lifecycle.md
@@ -74,17 +74,16 @@ reviewed OIDC drift reconciliation in Gate B.
 
 ## 5. Required ignored runtime files
 
-Per stack, a real (gitignored) `backend.hcl` and, where applicable, real
-`environments/demo/*.tfvars` must already exist locally — these are never
-committed (see `.gitignore`: `backend.hcl`, `*.tfvars` with
-`!*.tfvars.example`, `**/.terraform/*`, `*.tfstate*`). This runbook assumes
-they are already in place; it does not create or copy them.
+Since #203, `account`, `foundation`, `data` and `ecs` authenticate to their HCP Terraform workspace via
+`terraform login app.terraform.io` — there is no `backend.hcl` for these roots any more. Per stack, real
+(gitignored) `environments/demo/*.tfvars` must already exist locally where applicable — these are never
+committed (see `.gitignore`: `*.tfvars` with `!*.tfvars.example`, `**/.terraform/*`, `*.tfstate*`). This
+runbook assumes they are already in place; it does not create or copy them.
 
 ```bash
+# HCP Terraform authentication check, never print the token:
+[ -s ~/.terraform.d/credentials.tfrc.json ] && echo "HCP Terraform credential present" || echo "MISSING: run terraform login app.terraform.io"
 # Presence-only check, never print contents:
-for stack in account data ecs foundation; do
-  [ -f "infra/terraform/$stack/backend.hcl" ] && echo "$stack: backend.hcl present" || echo "$stack: MISSING backend.hcl"
-done
 for f in foundation data ecs; do
   [ -f "infra/terraform/environments/demo/$f.tfvars" ] && echo "$f.tfvars present" || echo "MISSING $f.tfvars"
 done

--- a/docs/runbooks/hcp-terraform-workspaces.md
+++ b/docs/runbooks/hcp-terraform-workspaces.md
@@ -5,11 +5,12 @@
 **Blocks:** #203 — Terraform state migration to HCP Terraform
 **Spec:** `docs/infrastructure-hcp-jenkins-spec.md` §6–§10
 
-> Status: EXECUTED. The HCP Terraform project and all four workspaces
-> described below have been created and verified empty. **No Terraform
-> state has been migrated, uploaded or generated anywhere in this issue.**
-> The real `terraform_remote_state` output-read proof against these
-> workspaces is deferred to #203.
+> Status: EXECUTED (#202) and MIGRATED (#203). The HCP Terraform project and
+> all four workspaces described below were created and verified empty under
+> #202; §10 records the executed #203 state migration. **HCP Terraform is now
+> the active and authoritative state backend** for `account`, `foundation`,
+> `data` and `ecs`. The former S3 state objects are retained historical
+> recovery copies only and are retired by #209.
 
 ---
 
@@ -205,19 +206,265 @@ runbook and the README pointer) needs to be touched to roll this back.
 
 ---
 
-## 9. Explicit non-goals of this issue
+## 9. Explicit non-goals of #202
 
-- **No Terraform state was migrated, uploaded or generated.** All four
-  workspaces remain empty on completion of this issue.
-- No `.tf` file was modified. `infra/terraform/ecs/remote_state.tf` still
-  reads `foundation`/`data`/`account` state via the S3 backend — switching
-  it to `backend = "remote"` is #203's job.
+These were the boundaries of #202 only. #203 (§10) subsequently performed the
+state migration.
+
+- **#202 migrated, uploaded or generated no Terraform state.** All four
+  workspaces were empty on completion of that issue.
+- #202 modified no `.tf` file.
 - No AWS resource was created, changed or read.
 - No Jenkins configuration or credential was created.
 - No GitHub Actions workflow, secret, or variable was touched.
 
-**Next step:** #203 migrates the `account` state (the only non-empty
-state) onto `itassetpulse-account`, and cleanly re-initializes
-`foundation`, `data` and `ecs` onto their respective empty workspaces —
-proving the remote-state-consumer configuration recorded in §5 by having
-`itassetpulse-ecs` actually read the other three workspaces' outputs.
+---
+
+## 10. Executed migration record (#203)
+
+| Item | Value |
+|---|---|
+| Migration date | 2026-08-03 |
+| Issue | #203 — *infra: migrate Terraform state to HCP Terraform* |
+| Branch | `infra/203-migrate-state-to-hcp-terraform` |
+| Configuration commit 1 | `b33a5e05cae4ffe1697cfb17e6bb3ed6176f3314` — *refactor(infra): replace S3 backend with HCP Terraform cloud blocks* |
+| Configuration commit 2 | `de9f9c42c35b99458df3e02ea9917992c8d615d7` — *refactor(infra): read upstream state from HCP Terraform workspaces* |
+| Terraform CLI | **1.10.5**, pinned deliberately so the issue changed the backend only and did not smuggle in a CLI or state-format upgrade. The locally installed 1.15.7 was not used for any state-touching command. |
+| Release checksum | `terraform_1.10.5_linux_amd64.zip` SHA-256 `0566a24f5332098b15716ebc394be503f4094acba5ba529bf5eb0698ed5e2a90`, verified against HashiCorp's published `SHA256SUMS` before the binary was extracted or executed |
+
+### 10.1 Workspace mapping
+
+| Root | HCP workspace | Execution mode | Outcome |
+|---|---|---|---|
+| `account` | `itassetpulse-account` | Local | State migrated (the only non-empty state) |
+| `foundation` | `itassetpulse-foundation` | Local | Clean initialization; no state snapshot |
+| `data` | `itassetpulse-data` | Local | Clean initialization; no state snapshot |
+| `ecs` | `itassetpulse-ecs` | Local | Clean initialization; no state snapshot |
+| `bootstrap` | — | — | **Not migrated.** Keeps local state; retired by #209 |
+
+### 10.2 Account state baseline — seven managed resources
+
+The verified pre-migration state held **seven** managed resources and **five**
+data-source addresses. All seven were migrated unchanged:
+
+```text
+aws_budgets_budget.monthly_cost
+aws_iam_openid_connect_provider.github_actions[0]
+aws_iam_role.image_publish
+aws_iam_role_policy.image_publish
+aws_sns_topic.budget_alerts
+aws_sns_topic_policy.budget_alerts
+aws_sns_topic_subscription.budget_alerts_email
+```
+
+Data sources (supporting evidence, not part of the acceptance count):
+`data.aws_caller_identity.current`, three `data.aws_iam_policy_document.*`,
+`data.aws_partition.current`.
+
+> **Historical correction.** #203's issue body, `docs/infrastructure-hcp-jenkins-spec.md` §8 and the
+> #201/#202 documents all stated *six* managed resources. That was a planning assumption inherited from
+> #201 and never checked against the real state. The #203 Gate 4 preflight read the state and found
+> **seven** — the extra address is `aws_iam_openid_connect_provider.github_actions[0]`, present because the
+> real (git-ignored) `account/terraform.tfvars` keeps `create_oidc_provider = true`. The GitHub OIDC
+> provider was a legitimate managed member of the state throughout #203 and was **preserved unchanged**.
+> **#203 did not remove it**; its removal belongs to **#207**.
+
+### 10.3 Migration metadata semantics
+
+The migration used the official HCP Terraform CLI workflow: the `backend "s3" {}`
+block was replaced by a `cloud` block, the previous `.terraform/` metadata was
+kept, and a plain `terraform init -lockfile=readonly` detected the change and
+interactively offered to copy the state. No `-migrate-state`, `-force-copy` or
+`-reconfigure` was used.
+
+| Observation | State format | Writer Terraform version | Managed count | Serial |
+|---|---|---|---|---|
+| Source (S3), pre-migration | 4 | 1.10.5 | 7 | 3 |
+| Initial HCP observation | 4 | 1.10.5 | 7 | 1 (HCP workspace serial) |
+
+- The source and HCP lineages **differed**: HCP Terraform established a new
+  workspace-local lineage for the previously empty workspace. Lineage values are
+  recorded in protected out-of-repository evidence, not here.
+- The HCP lineage remained **stable across every later HCP observation**, and the
+  HCP serial was **non-decreasing** throughout.
+- **Cross-backend lineage equality and continuation of the source serial were
+  removed as acceptance assumptions** — they are not part of what the CLI
+  migration workflow promises. The migration copies the latest state snapshot; it
+  does not carry the source backend's state-history identity across.
+- The HCP API defines serial as the state-version sequence *within* the
+  workspace, so serial `1` is correct for the first state version in a previously
+  empty workspace.
+
+Do not compare the S3 serial numerically against the HCP serial, and do not
+require the two lineages to match.
+
+### 10.4 Account plan result — migration integrity vs. pre-existing AWS drift
+
+These are two separate findings and must not be conflated.
+
+**Migration integrity: passed.**
+
+- Sorted managed-resource address lists identical before and after (7 = 7).
+- Data-source address lists identical (5 = 5).
+- `terraform validate` succeeded.
+- No state mutation was caused by any verification step.
+
+**Pre-existing AWS drift: detected, deferred to #207.**
+
+- `terraform plan -detailed-exitcode` returned **exit code `2`**. This account
+  plan is **not** a no-op, and #203 does **not** claim `exit 0`.
+- The exit code was **not caused by the backend migration**. The same plan would
+  have produced it against the S3 backend.
+- The AWS refresh found that `aws_iam_openid_connect_provider.github_actions[0]`
+  is **already absent from AWS** — it was removed out-of-band.
+- Configuration and state still intentionally contain that resource, so Terraform
+  proposed **re-creating** it, plus an **in-place update** of the dependent
+  `aws_iam_role.image_publish` (whose trust policy depends on the provider ARN).
+- **No destroy and no replacement** was proposed. No unrelated resource change
+  was identified.
+- **No apply was run.** #203 must not re-create the OIDC provider.
+- #207 resolves this by removing the resource from the configuration, which is
+  also what milestone #25's exit criteria require.
+
+### 10.5 Empty-root initialization
+
+The old S3 states for `foundation`, `data` and `ecs` were each verified to hold
+**zero** state addresses *before* the backend configuration changed. Each root was
+then cleanly initialized against its HCP workspace — no state migration was
+attempted, because there was nothing to move.
+
+| Root | `init` | `validate` | HCP resource count | HCP state versions | `state list` |
+|---|---|---|---|---|---|
+| `foundation` | exit 0 | Success | 0 | 0 | exit 1, `No state file was found!` |
+| `data` | exit 0 | Success | 0 | 0 | exit 1, `No state file was found!` |
+| `ecs` | exit 0 | Success | 0 | 0 | exit 1, `No state file was found!` |
+
+No migration, rename or workspace-selection prompt appeared for any root.
+
+> **Empty snapshot vs. no snapshot.** Against the S3 backend these roots had an
+> *empty state object*, so `terraform state list` exited `0` and printed nothing.
+> An HCP workspace that has never had a run has **no state version at all**, which
+> Terraform reports as `No state file was found!` with exit `1`. That is a
+> stronger form of empty, and it was accepted as such: **no artificial empty state
+> was uploaded or created**. A future real `terraform apply` will create the first
+> state version. (For contrast, `account` — which does have a state version —
+> returns exit `0`.)
+
+### 10.6 ECS remote-state verification
+
+Verification history, kept because two earlier probes were inconclusive for
+instructive reasons:
+
+1. **Plain `terraform console`** returned `(known after apply)`. Inconclusive:
+   the ECS workspace has no state, so the data source had never been evaluated
+   and console does not resolve it on demand.
+2. **First targeted-plan extraction** read only
+   `data.terraform_remote_state.account` successfully, but its JSON filter
+   inspected `planned_values` — empty here, because the targeted read-only plan
+   creates no persistent planned root resource.
+3. **Accepted verification (Gate 8C).** A targeted plan evaluated **exactly one**
+   data source, `data.terraform_remote_state.account`:
+   - plan exit code `0`, no error of any class;
+   - **no AWS credentials were available** (blanked environment, empty
+     credentials/config files, IMDS disabled);
+   - no `foundation`, `data`, AWS, Atlas, managed-resource or unrelated
+     data-source read occurred;
+   - the refreshed `prior_state` contained exactly one matching
+     `terraform_remote_state` data source;
+   - its root-output map contains the **`sns_topic_arn` key**;
+   - the output **value** was never selected, displayed or persisted;
+   - managed-resource change count `0`; unrelated data-source change count `0`;
+   - no ECS state version was created;
+   - the temporary binary plan was protected (mode 600, outside the repository)
+     and deleted immediately after extraction; it was never applied or committed.
+
+**Functional Local-execution remote-state access is verified.** Two qualifications:
+
+- The HCP consumer matrix (§5) separately proves the intended ECS-only sharing
+  configuration.
+- In Local execution mode the authenticated user token *also* holds workspace
+  permissions, so this local functional read must **not** be presented as
+  isolated proof that the consumer grant alone enforced access.
+
+For `foundation` and `data`, the exact ECS-only consumer grants are verified, but
+**no output read is possible** until those roots have real state snapshots and
+outputs.
+
+### 10.7 CI reproduction
+
+All six Terraform CI-equivalent jobs were reproduced locally in a disposable
+clone of the committed branch, with a cleared environment and an empty `HOME` —
+no AWS and no HCP Terraform credential was reachable. All `fmt -check`,
+`init -backend=false` and `validate` commands passed, confirming that
+`-backend=false` skips *HCP Terraform* initialization just as it skips a
+backend.
+
+- **No tracked file changed** in the clone.
+- The only untracked result was a generated
+  `infra/terraform/modules/ecs-fargate-service/.terraform.lock.hcl`. That module
+  has **no tracked lock file**, which is why its CI job deliberately omits
+  `-lockfile=readonly`. A byte-identical file (SHA-256
+  `b71a0a8adf9feafdc24fdd5985c5722b8ec8bc145bf245c53e161c105e6298a7`) was
+  generated from the **untouched baseline commit** `5be6a71`, so the behaviour
+  predates #203 and is unrelated to it. The clone's `git status` was therefore
+  not entirely empty, and this record does not claim it was.
+- The disposable clone was deleted.
+- `.github/workflows/ci.yml` was **not** modified.
+
+At the time of writing, only this local credential-free reproduction has run;
+the GitHub Actions result is not yet recorded.
+
+### 10.8 Tracked lock-file integrity
+
+The tracked lock-file inventory (`git ls-files 'infra/terraform/**/.terraform.lock.hcl'`)
+was recorded at preflight and every file was verified unchanged at every gate.
+Every `terraform init` in this issue used `-lockfile=readonly`, so lock-file
+churn would have failed the command rather than silently rewriting a tracked file.
+
+### 10.9 Cleanup and legacy-plan retirement
+
+- The four tracked `backend.hcl.example` files were deleted in configuration
+  commit 1.
+- The four git-ignored real `backend.hcl` files were each verified byte-identical
+  to a protected out-of-repository backup, then deleted. Their contents were never
+  displayed or parsed. No `backend.hcl` remains anywhere in the repository.
+- The two legacy saved plans matched their expected sizes and SHA-256 hashes
+  exactly:
+
+| Plan | Size | SHA-256 |
+|---|---|---|
+| `infra/terraform/foundation/gate-b-foundation-apply.tfplan` | 14267 | `629947b6fdbdca3ba102569a592beb03820d8b6e0561fc4b43234af3323a30b5` |
+| `infra/terraform/account/gate-oidc-recovery-account.tfplan` | 18354 | `ce2257d8501dc4eb78e7f9f39cb54e2fc9c6007429e00db92f61f0211ad955c2` |
+
+  Their metadata was recorded in an evidence comment on issue #203, after which
+  both files were deleted. Neither plan was displayed, interpreted, applied,
+  regenerated, renamed or copied — only `stat` and `sha256sum` touched them.
+- The protected backend-configuration and pre-migration local-backend-metadata
+  backups are retained temporarily, outside the repository, until #203 merges.
+
+### 10.10 No AWS infrastructure mutation
+
+**No AWS resource was created, modified or destroyed by #203.** The issue changed
+where Terraform state is stored, nothing about what exists in AWS. The only AWS
+interactions were reads: the pre-migration state read, `sts get-caller-identity`,
+and the provider refresh during `terraform plan`. No `apply`, `destroy`,
+`import`, `state push`, `state rm`, `state mv`, `force-unlock`, `-force-copy` or
+`-reconfigure` was run at any point. No MongoDB Atlas call was made.
+
+### 10.11 State authority
+
+Since the `account` migration passed its integrity checks:
+
+- **HCP Terraform is the single active and authoritative backend** for `account`,
+  `foundation`, `data` and `ecs`.
+- The S3 state objects are **retained historical recovery copies only**. They were
+  not read or written by any command after the migration and remain untouched.
+- Retiring the S3 bucket and the `bootstrap` stack is **#209**.
+
+### 10.12 Next steps
+
+- **#207** — remove the superseded GitHub Actions OIDC provider and the old
+  image-publish path, resolving the drift recorded in §10.4.
+- **#205, #208, #200** — unblocked by this migration.
+- **#209** — retire the S3 state bucket and the `bootstrap` stack after the
+  rebuild in #200 proves the new model.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -3,15 +3,14 @@
 Modular Terraform for the ITAssetPulse ephemeral demo. Design of record:
 [`docs/infrastructure-modularization-spec.md`](../../docs/infrastructure-modularization-spec.md).
 
-> The S3 remote-state backend and apply model described below are being migrated to HCP Terraform and a local
-> Jenkins execution model; see
-> [`docs/infrastructure-hcp-jenkins-spec.md`](../../docs/infrastructure-hcp-jenkins-spec.md) for the planned
-> target architecture. That broader migration is still in progress.
+> **HCP Terraform is the active and authoritative state backend** for `account`, `foundation`, `data` and
+> `ecs` (#203) — see [`docs/runbooks/hcp-terraform-workspaces.md`](../../docs/runbooks/hcp-terraform-workspaces.md)
+> for the executed migration record. The former S3 state objects are retained historical recovery copies
+> only; they are no longer read or written, and retiring them together with the `bootstrap` stack is #209.
 >
-> The HCP Terraform project and its four workspaces listed below have been created and verified empty (#202)
-> — see [`docs/runbooks/hcp-terraform-workspaces.md`](../../docs/runbooks/hcp-terraform-workspaces.md). No
-> Terraform state has been migrated onto them yet: the S3 backend and the state-key table below remain
-> authoritative until #203.
+> The broader move to a local Jenkins execution model is still in progress; see
+> [`docs/infrastructure-hcp-jenkins-spec.md`](../../docs/infrastructure-hcp-jenkins-spec.md) for the target
+> architecture.
 
 > **The modular Terraform roots are implemented. The `foundation`, `data` and ECS demo resources are currently
 > not provisioned in AWS. Any future mutation requires a reviewed saved plan and explicit approval.**
@@ -37,32 +36,33 @@ infra/terraform/
     demo/                    # per-stack *.tfvars for the demo environment
 ```
 
-## State-key convention
+## State backend convention
 
-Remote state lives in the S3 bucket created by `bootstrap`. Each remote-state root stack uses a distinct key
-via its own `backend.hcl` (partial backend config):
+Each remote-state root stack stores its state in its own HCP Terraform workspace, declared by a `cloud`
+block in the stack's `backend.tf`. Organization: `gabor-toth-personalprojects`.
 
-| Stack | State | Key |
-|-------|-------|-----|
-| `bootstrap` | local | — (creates the bucket) |
-| `account` | remote | `itassetpulse/global/account.tfstate` |
-| `foundation` | remote | `itassetpulse/demo/foundation.tfstate` |
-| `data` | remote | `itassetpulse/demo/data.tfstate` |
-| `ecs` | remote | `itassetpulse/demo/ecs.tfstate` |
-| `eks` (later) | remote | `itassetpulse/demo/eks.tfstate` |
+| Stack | State | HCP workspace | Execution mode |
+|-------|-------|---------------|----------------|
+| `bootstrap` | local | — | — (local state; retired by #209) |
+| `account` | HCP Terraform | `itassetpulse-account` | Local (CLI-driven) |
+| `foundation` | HCP Terraform | `itassetpulse-foundation` | Local (CLI-driven) |
+| `data` | HCP Terraform | `itassetpulse-data` | Local (CLI-driven) |
+| `ecs` | HCP Terraform | `itassetpulse-ecs` | Local (CLI-driven) |
 
-## HCP Terraform workspace inventory (empty, prepared by #202)
+**Local execution mode** means HCP Terraform stores the state and its version history; `plan` and `apply`
+still run on the operator's machine (or, later, on the local Jenkins). HCP Terraform never executes a run.
 
-| Stack | HCP workspace | Execution mode |
-|-------|---------------|----------------|
-| `account` | `itassetpulse-account` | Local (CLI-driven) |
-| `foundation` | `itassetpulse-foundation` | Local (CLI-driven) |
-| `data` | `itassetpulse-data` | Local (CLI-driven) |
-| `ecs` | `itassetpulse-ecs` | Local (CLI-driven) |
+Remote-state sharing is least-privilege: `itassetpulse-account`, `itassetpulse-foundation` and
+`itassetpulse-data` each list `itassetpulse-ecs` as their only remote-state consumer, and `itassetpulse-ecs`
+shares its state with nobody. No workspace uses project-wide or organization-wide sharing.
+
+> Historical: before #203 these four roots used an S3 backend with per-stack keys
+> (`itassetpulse/global/account.tfstate`, `itassetpulse/demo/{foundation,data,ecs}.tfstate`) supplied through
+> a git-ignored `backend.hcl`. Those state objects are retained recovery copies only and are no longer used;
+> the `backend.hcl` workflow and the `backend.hcl.example` files are gone.
 
 See [`docs/runbooks/hcp-terraform-workspaces.md`](../../docs/runbooks/hcp-terraform-workspaces.md) for the
-project, remote-state-sharing configuration and token lifecycle. State migration onto these workspaces is
-#203.
+project, the sharing configuration, the token lifecycle and the executed migration record.
 
 ## Environment convention
 
@@ -70,27 +70,31 @@ project, remote-state-sharing configuration and token lifecycle. State migration
 - Environment-scoped stacks (`foundation`, `data`, `ecs`) take `project_name`, `environment`, `common_tags`,
   and read their values from `environments/<env>/<stack>.tfvars`.
 - `bootstrap` and `account` are environment-agnostic (account/region-scoped) and keep their own tfvars.
-- Real `*.tfvars`, `backend.hcl`, state files, and `.terraform/` are git-ignored; only `*.example` files are
-  tracked.
+- Real `*.tfvars`, state files, and `.terraform/` are git-ignored; only `*.example` files are tracked. There
+  is no `backend.hcl` any more — the `cloud` block carries the full backend configuration.
 
 ## Run conventions (only once a stack's implementation issue has added its `.tf`)
 
 ```bash
+terraform login app.terraform.io              # once per machine; token stored outside the repository
 cd infra/terraform/<stack>
-cp backend.hcl.example backend.hcl            # then edit (bootstrap uses local state — no backend.hcl)
-terraform init -backend-config=backend.hcl
+terraform init                                # no -backend-config; the cloud block is complete
 terraform fmt -check
 terraform validate
 terraform plan  -var-file=../environments/demo/<stack>.tfvars
 terraform apply -var-file=../environments/demo/<stack>.tfvars
 ```
 
+`bootstrap` keeps local state and takes no `terraform login` or `cloud` block.
+
 Apply / dependency order: `bootstrap → account → foundation → data → (publish images) → ecs`. See spec §13.
 
 ## CI validation
 
-`.github/workflows/ci.yml` runs AWS-free quality gates on every pull request and push to `main` — no AWS
-credentials are ever configured in CI. Each currently-implemented root stack has its own job running
+`.github/workflows/ci.yml` runs credential-free quality gates on every pull request and push to `main` —
+**neither AWS nor HCP Terraform credentials are ever configured in CI**. `terraform init -backend=false`
+skips *backend or HCP Terraform initialization*, so the `cloud` blocks do not make CI reach
+`app.terraform.io`. Each currently-implemented root stack has its own job running
 `terraform fmt -check -recursive`, `terraform init -backend=false -lockfile=readonly`, and `terraform
 validate`:
 

--- a/infra/terraform/account/README.md
+++ b/infra/terraform/account/README.md
@@ -1,7 +1,15 @@
 # stack: account (remote state, persistent)
 
 Persistent account-level guardrails and CI identity that survive demo teardown. Spec: §4.2.
-State key: `itassetpulse/global/account.tfstate`.
+State: HCP Terraform workspace `itassetpulse-account` (organization `gabor-toth-personalprojects`),
+Local execution mode. Migrated from the former S3 backend in #203.
+
+> **Known drift — owned by #207.** The account state holds **seven** managed resources, including
+> `aws_iam_openid_connect_provider.github_actions[0]`. AWS no longer has that provider (it was removed
+> out-of-band), so a plan currently proposes re-creating it plus an in-place update of the dependent
+> `aws_iam_role.image_publish`. **Do not apply this stack while that drift is open** — #203 deliberately
+> preserved the resource unchanged, and #207 resolves it by removing it from the configuration rather than
+> by re-creating it in AWS.
 
 ## What it creates
 
@@ -22,6 +30,27 @@ State key: `itassetpulse/global/account.tfstate`.
 
 No IAM resource for the state-access contract, no VPC/ECR/Atlas/ECS/ALB resource, no application code, no
 image-publish workflow — all out of scope for this stack.
+
+## State baseline (verified in #203)
+
+Seven managed resources and five data-source addresses. All seven were migrated to HCP Terraform unchanged:
+
+```text
+aws_budgets_budget.monthly_cost
+aws_iam_openid_connect_provider.github_actions[0]
+aws_iam_role.image_publish
+aws_iam_role_policy.image_publish
+aws_sns_topic.budget_alerts
+aws_sns_topic_policy.budget_alerts
+aws_sns_topic_subscription.budget_alerts_email
+```
+
+> **Historical correction.** #201/#202/#203 planning documents stated that this state held *six* managed
+> resources. That figure was an inherited assumption, never verified against the state. The #203 Gate 4
+> preflight read the real state and found **seven**: the extra address is
+> `aws_iam_openid_connect_provider.github_actions[0]`, present because the real (git-ignored)
+> `terraform.tfvars` keeps `create_oidc_provider = true`. It was a legitimate managed member of the state
+> throughout #203 and was preserved unchanged; **#203 did not remove it**. Its removal belongs to #207.
 
 ## Inputs / outputs
 
@@ -114,12 +143,18 @@ Runtime-verification order after apply:
 Before destroying this stack, separately verify the subscription's confirmation status — an unconfirmed
 subscription cannot be properly removed by Terraform (see above).
 
-## State-access IAM contract (documentation only — no IAM resource beyond the image-publish role)
+## State access (no AWS IAM state contract any more)
 
-Any identity that runs a remote-state stack needs, on the state bucket and its objects, the same S3
-state/lock contract documented in `bootstrap/README.md` (§4.1): `s3:ListBucket`; `s3:GetObject` /
-`s3:PutObject` on the state object (no `s3:DeleteObject`); `s3:GetObject` / `s3:PutObject` /
-`s3:DeleteObject` on the lock object. No KMS permissions (SSE-S3).
+Since #203 the state lives in HCP Terraform, so no AWS IAM permission is needed to read or write it. An
+operator needs:
+
+- an HCP Terraform token obtained with `terraform login app.terraform.io`, stored outside the repository;
+- membership of the `gabor-toth-personalprojects` organization with access to the `itassetpulse-account`
+  workspace;
+- AWS credentials only for the *provider* operations (refresh/plan/apply against AWS), never for state.
+
+The former S3 state/lock IAM contract is historical and applies only to the `bootstrap` stack until #209
+retires it.
 
 ## IAM role recreation
 
@@ -132,10 +167,11 @@ to be free of downstream impact:
 
 ## Recovery / import (remote state lost or corrupted)
 
-The account state lives in S3 (versioned), unlike the bootstrap stack's local state:
+The account state lives in HCP Terraform, which keeps a full state-version history per workspace:
 
-1. Preferred: restore a prior **S3 object version** of `itassetpulse/global/account.tfstate`
-   (`aws s3api list-object-versions`, then copy the desired version back onto the current key).
+1. Preferred: roll back to a prior **HCP Terraform state version** of the `itassetpulse-account` workspace
+   from the workspace's *States* view. Any state rollback requires explicit approval and a separately
+   reviewed procedure — it is never routine.
 2. If that is not possible:
    1. import **all** relevant managed resources first (table below);
    2. only then run a single, full `terraform plan`;
@@ -169,21 +205,24 @@ recreate:
 
 ## Remote-state locking verification
 
-No dedicated, parallel test observing the short-lived `.tflock` object is required. The runtime
+HCP Terraform locks the workspace itself; there is no `.tflock` object to observe. The runtime
 verification instead confirms:
 
-- `use_lockfile = true` in `backend.hcl`;
-- a successful remote backend init (`terraform init -backend-config=backend.hcl`);
+- a successful `terraform init` against the `itassetpulse-account` workspace;
+- the workspace reports `locked = false` and no active run before starting;
 - a successful saved plan (`terraform plan -out=tfplan`);
-- the `itassetpulse/global/account.tfstate` state object exists in the bucket after apply;
-- no stale `.tflock` object remains after the operation completes;
-- a no-op plan (`terraform plan -detailed-exitcode`, exit `0`).
+- the workspace has a finalized current state version after apply;
+- a no-op plan (`terraform plan -detailed-exitcode`, exit `0`) — **currently not achievable** while the
+  #207 OIDC drift above is open; see that note before treating a non-zero exit code as a regression.
 
 ## Order
 
-Preflight (repeated before every apply) → `terraform init -backend-config=backend.hcl` →
-`terraform plan -out` → review → separate apply approval → apply. This stack does not depend on
-`foundation`/`data`/`ecs` (spec §6); future modifications (e.g., a `budget_limit_usd` change, a different
-`github_branch`) go through the same persistent state, no special reordering needed.
+Preflight (repeated before every apply) → `terraform init` → `terraform plan -out` → review → separate
+apply approval → apply. This stack does not depend on `foundation`/`data`/`ecs` (spec §6); future
+modifications (e.g., a `budget_limit_usd` change, a different `github_branch`) go through the same
+persistent state, no special reordering needed.
+
+The `aws s3api head-bucket` line in the preflight above is historical: it checked the S3 state bucket, which
+is no longer the state backend. It stays relevant only for `bootstrap` until #209.
 
 Implemented in: **#173**.

--- a/infra/terraform/account/backend.hcl.example
+++ b/infra/terraform/account/backend.hcl.example
@@ -1,7 +1,0 @@
-# account — S3 remote backend (partial config).
-# Copy to backend.hcl (git-ignored) and set the bucket created by the bootstrap stack.
-bucket       = "<your-terraform-state-bucket>"
-key          = "itassetpulse/global/account.tfstate"
-region       = "<your-aws-region>"
-encrypt      = true
-use_lockfile = true

--- a/infra/terraform/account/backend.tf
+++ b/infra/terraform/account/backend.tf
@@ -1,5 +1,13 @@
 terraform {
-  # Partial configuration: real values come from backend.hcl (git-ignored),
-  # supplied via `terraform init -backend-config=backend.hcl`.
-  backend "s3" {}
+  # State is stored in HCP Terraform. The workspace runs in Local execution
+  # mode: HCP Terraform holds the state, plan/apply still run locally.
+  # Authentication comes from `terraform login app.terraform.io`; no token is
+  # ever written into this file.
+  cloud {
+    organization = "gabor-toth-personalprojects"
+
+    workspaces {
+      name = "itassetpulse-account"
+    }
+  }
 }

--- a/infra/terraform/bootstrap/README.md
+++ b/infra/terraform/bootstrap/README.md
@@ -2,9 +2,14 @@
 
 Creates **only** the Terraform remote-state infrastructure. Spec: §4.1.
 
-This stack uses **local state** and creates nothing else. Every other stack (`account`, `foundation`,
-`data`, `ecs`) uses the S3 backend created here. Persistent guardrails (Budget, SNS, GitHub OIDC) live in the
-`account` stack, not here.
+This stack uses **local state** and creates nothing else. Persistent guardrails (Budget, SNS, GitHub OIDC)
+live in the `account` stack, not here.
+
+> **Status after #203.** `account`, `foundation`, `data` and `ecs` **no longer use the S3 bucket created
+> here** as their active backend — they use HCP Terraform Local execution workspaces, and their
+> `backend.hcl` workflow was removed by #203. This stack still uses local state and still owns the bucket,
+> which is retained as a historical recovery copy only. Everything below describes that historical model.
+> Retiring the bucket and this stack is **#209**.
 
 ## What it creates
 
@@ -14,13 +19,16 @@ This stack uses **local state** and creates nothing else. Every other stack (`ac
 - `aws_s3_bucket_public_access_block` — all four settings enabled.
 - `aws_s3_bucket_ownership_controls` — `BucketOwnerEnforced` (ACLs disabled).
 
-No DynamoDB table: remote-state stacks lock with the **S3 native lockfile** (`use_lockfile = true` in their
-`backend.hcl`), which writes a `<key>.tflock` object next to each state key in this same bucket.
+No DynamoDB table: while the four remote-state roots still used this bucket, they locked with the **S3 native
+lockfile** (`use_lockfile = true` in their `backend.hcl`), which wrote a `<key>.tflock` object next to each
+state key in this same bucket. Since #203 those roots lock through their HCP Terraform workspace instead.
 
 ## Inputs / outputs
 
 - Inputs (environment-agnostic): `project_name`, `aws_region`. See `terraform.tfvars.example`.
-- Outputs: `state_bucket_name`, `state_bucket_region`.
+- Outputs: `state_bucket_name`, `state_bucket_region`. Since #203 these are **historical/recovery context
+  only** — do **not** configure `account`, `foundation`, `data` or `ecs` from them. Those roots take their
+  backend from the `cloud` block committed in their own `backend.tf`.
 
 ### Bucket name
 
@@ -44,7 +52,8 @@ terraform plan
 terraform apply
 ```
 
-After apply, the other stacks point their `backend.hcl` `bucket` at `state_bucket_name`.
+Historically, the other stacks then pointed their `backend.hcl` `bucket` at `state_bucket_name`. That step is
+**obsolete**: since #203 they use HCP Terraform workspaces and have no `backend.hcl`.
 
 ### Back up the local state
 
@@ -69,9 +78,11 @@ uses (no wildcards):
 - `s3:PutBucketOwnershipControls`, `s3:GetBucketOwnershipControls`
 - `s3:PutBucketTagging`, `s3:GetBucketTagging`
 
-### 2. Downstream backend identity
+### 2. Downstream backend identity (historical — no longer required)
 
-Any identity that runs a remote-state stack, on the state bucket and its objects:
+This contract applied while the four remote-state roots used this bucket. Since #203 they authenticate to
+HCP Terraform instead and need no AWS permission for state at all. Kept for recovery context until #209.
+On the state bucket and its objects it required:
 
 - `s3:ListBucket` on `arn:aws:s3:::<state-bucket>` (optionally condition-scoped to the relevant key prefixes).
 - On the **state object** `arn:aws:s3:::<state-bucket>/<key>`: `s3:GetObject`, `s3:PutObject`. **No

--- a/infra/terraform/data/README.md
+++ b/infra/terraform/data/README.md
@@ -1,6 +1,14 @@
 # stack: data (remote state, ephemeral)
 
-External database wiring. Spec: §4.4. State key: `itassetpulse/demo/data.tfstate`.
+External database wiring. Spec: §4.4.
+State: HCP Terraform workspace `itassetpulse-data` (organization `gabor-toth-personalprojects`),
+Local execution mode. Cleanly initialized against HCP Terraform in #203; the former S3 state was verified
+empty beforehand and is a retained historical recovery copy only (retired by #209).
+
+> **This workspace has no state snapshot yet.** `terraform state list` therefore exits `1` with
+> `No state file was found!` rather than exiting `0` with no output — the workspace has *never* had a state
+> version, which is different from holding an empty one. That is expected and must not be "repaired": no
+> artificial empty state was uploaded. The first real `terraform apply` creates the first state version.
 
 ## What it creates
 
@@ -72,7 +80,7 @@ exclusively by the committed `.terraform.lock.hcl` — this README intentionally
 - The full `MONGO_URI` can land in the Terraform **state and in a saved plan file**.
 - Terraform's `sensitive = true` marking (used where applicable) only masks the normal CLI output — it does
   **not** redact a `terraform show -json` export of a plan or state, and does not encrypt the value at rest
-  beyond the state backend's own encryption (S3 SSE-S3, per the `bootstrap` stack).
+  beyond the state backend's own encryption (HCP Terraform encrypts stored state at rest).
 - Treat `tfplan`/`destroy.tfplan` and the remote state with the same care as a credential file.
 
 ## Read-only preflight (before every apply)
@@ -108,12 +116,12 @@ aws secretsmanager list-secrets \
 ## Order
 
 ```bash
+terraform login app.terraform.io                                               # once per machine
 cd infra/terraform/data
-cp backend.hcl.example backend.hcl                                             # fill in the bootstrap-created bucket
 cp ../environments/demo/data.tfvars.example ../environments/demo/data.tfvars   # fill in real Atlas project id / SRV host
 export MONGODB_ATLAS_CLIENT_ID=...
 export MONGODB_ATLAS_CLIENT_SECRET=...
-terraform init -backend-config=backend.hcl
+terraform init                                                                 # cloud block; no -backend-config
 terraform plan  -var-file=../environments/demo/data.tfvars -out=tfplan
 terraform apply "tfplan"
 ```
@@ -145,8 +153,8 @@ Post-destroy read-only verification:
 - the Atlas database user no longer exists;
 - the Secrets Manager secret is gone and not in a pending-deletion state (`recovery_window_in_days = 0`
   means immediate deletion, not scheduled);
-- `terraform state list` is empty;
-- no stale `.tflock` remains in the state bucket;
+- `terraform state list` reports no managed resource;
+- the `itassetpulse-data` HCP Terraform workspace is unlocked and has no active run;
 - `bootstrap` and `account` infrastructure are untouched;
 - the local `destroy.tfplan` is deleted after verification.
 

--- a/infra/terraform/data/backend.hcl.example
+++ b/infra/terraform/data/backend.hcl.example
@@ -1,7 +1,0 @@
-# data — S3 remote backend (partial config).
-# Copy to backend.hcl (git-ignored) and set the bucket created by the bootstrap stack.
-bucket       = "<your-terraform-state-bucket>"
-key          = "itassetpulse/demo/data.tfstate"
-region       = "<your-aws-region>"
-encrypt      = true
-use_lockfile = true

--- a/infra/terraform/data/backend.tf
+++ b/infra/terraform/data/backend.tf
@@ -1,5 +1,13 @@
 terraform {
-  # Partial configuration: real values come from backend.hcl (git-ignored),
-  # supplied via `terraform init -backend-config=backend.hcl`.
-  backend "s3" {}
+  # State is stored in HCP Terraform. The workspace runs in Local execution
+  # mode: HCP Terraform holds the state, plan/apply still run locally.
+  # Authentication comes from `terraform login app.terraform.io`; no token is
+  # ever written into this file.
+  cloud {
+    organization = "gabor-toth-personalprojects"
+
+    workspaces {
+      name = "itassetpulse-data"
+    }
+  }
 }

--- a/infra/terraform/ecs/README.md
+++ b/infra/terraform/ecs/README.md
@@ -1,6 +1,14 @@
 # stack: ecs (remote state, ephemeral)
 
-The ECS Fargate application stack. Spec: §4.5. State key: `itassetpulse/demo/ecs.tfstate`.
+The ECS Fargate application stack. Spec: §4.5.
+State: HCP Terraform workspace `itassetpulse-ecs` (organization `gabor-toth-personalprojects`),
+Local execution mode. Cleanly initialized against HCP Terraform in #203; the former S3 state was verified
+empty beforehand and is a retained historical recovery copy only (retired by #209).
+
+> **This workspace has no state snapshot yet.** `terraform state list` therefore exits `1` with
+> `No state file was found!` rather than exiting `0` with no output — the workspace has *never* had a state
+> version, which is different from holding an empty one. That is expected and must not be "repaired": no
+> artificial empty state was uploaded. The first real `terraform apply` creates the first state version.
 
 Delivered in two increments: the core increment (#180) creates the cluster, ALB, routing, secrets, and
 services; this observability increment (#181) adds CloudWatch alarms, a dashboard, and SNS notification
@@ -47,8 +55,26 @@ the repo):
   consumer until the alarms existed (`docs/infrastructure-modularization-spec.md` §4.5, §6, §7.1 note this
   split).
 
-The S3 bucket used for these remote-state reads comes from `var.state_bucket` (not hardcoded — the bucket
-name embeds the AWS account ID, spec §8).
+Since #203 each read is a `terraform_remote_state` data source with `backend = "remote"` against the
+producer's HCP Terraform workspace (`itassetpulse-foundation`, `itassetpulse-data`, `itassetpulse-account`).
+There is no `"cloud"` backend for this data source — `"remote"` is the correct and only option. The
+`var.state_bucket` input is gone; nothing about these reads is region- or bucket-scoped any more.
+
+Access is granted per workspace: each of the three producers lists `itassetpulse-ecs` as its **only**
+remote-state consumer, and `itassetpulse-ecs` shares its state with nobody. No project-wide or
+organization-wide sharing is enabled.
+
+**Verified in #203 (Gate 8C).** A targeted, credential-free `terraform plan -target=data.terraform_remote_state.account`
+read exactly one data source and succeeded: the refreshed plan state contained exactly one matching
+`terraform_remote_state` object whose root-output map contains the `sns_topic_arn` key. The output *value*
+was never selected or displayed; no managed-resource change and no unrelated data-source read occurred; no
+AWS credential was available; no ECS state version was created. Two caveats worth keeping in mind:
+
+- In Local execution mode the authenticated user token also carries workspace permissions, so this
+  functional read is **not** isolated proof that the consumer grant alone enforced access. The HCP consumer
+  matrix is separately verified evidence for the sharing configuration.
+- `foundation` and `data` have verified ECS-only consumer grants, but **no output read is possible** until
+  those roots hold real state snapshots with outputs.
 
 ## Target group ownership
 
@@ -98,8 +124,8 @@ module is digest-pinned: `<repository-url>@<image-digest>`.
 `random_password.jwt_secret` (64 chars, `special = true`) → `aws_secretsmanager_secret.jwt` (`name_prefix`,
 `recovery_window_in_days = 0`) → `aws_secretsmanager_secret_version.jwt`. **Trade-off:** the secret value is
 plaintext in Terraform state. No write-only argument is used — the AWS provider supports one, but it is
-disproportionate complexity for a demo project. This is acceptable because the state bucket is encrypted,
-blocks public access, and is reachable only through narrow IAM (spec §9); the value is never output; and
+disproportionate complexity for a demo project. This is acceptable because HCP Terraform encrypts stored
+state at rest and access is limited to the organization's authenticated members; the value is never output; and
 this is the same pattern `data` already uses for the Mongo URI secret. The backend module's `secrets` map
 gets `MONGO_URI` (from the `data` remote state) and `JWT_SECRET` (created here); the frontend gets no
 secrets.
@@ -184,7 +210,8 @@ Three fixed (non-variable) CloudWatch alarms and one dashboard, defined in `obse
 
 ## Inputs / outputs
 
-- Inputs: `project_name`, `environment`, `common_tags`, `aws_region`, `state_bucket`, `release_sha`,
+- Inputs: `project_name`, `environment`, `common_tags`, `aws_region` (the region this ECS stack deploys
+  into — it no longer has anything to do with where remote state lives), `release_sha`,
   `frontend_container_port`, `backend_container_port`, `frontend_cpu`/`frontend_memory`,
   `backend_cpu`/`backend_memory`, `frontend_desired_count`, `backend_desired_count`,
   `backend_health_check_grace_period_seconds`, `log_retention_days`. See
@@ -206,10 +233,10 @@ versions of both.
 ## Order
 
 ```bash
+terraform login app.terraform.io                                            # once per machine
 cd infra/terraform/ecs
-cp backend.hcl.example backend.hcl                                          # fill in the bootstrap-created bucket
-cp ../environments/demo/ecs.tfvars.example ../environments/demo/ecs.tfvars  # fill in real state_bucket / release_sha
-terraform init -backend-config=backend.hcl
+cp ../environments/demo/ecs.tfvars.example ../environments/demo/ecs.tfvars  # fill in real release_sha
+terraform init                                                              # cloud block; no -backend-config
 terraform plan  -var-file=../environments/demo/ecs.tfvars -out=tfplan
 terraform apply "tfplan"
 ```

--- a/infra/terraform/ecs/backend.hcl.example
+++ b/infra/terraform/ecs/backend.hcl.example
@@ -1,7 +1,0 @@
-# ecs — S3 remote backend (partial config).
-# Copy to backend.hcl (git-ignored) and set the bucket created by the bootstrap stack.
-bucket       = "<your-terraform-state-bucket>"
-key          = "itassetpulse/demo/ecs.tfstate"
-region       = "<your-aws-region>"
-encrypt      = true
-use_lockfile = true

--- a/infra/terraform/ecs/backend.tf
+++ b/infra/terraform/ecs/backend.tf
@@ -1,5 +1,13 @@
 terraform {
-  # Partial configuration: real values come from backend.hcl (git-ignored),
-  # supplied via `terraform init -backend-config=backend.hcl`.
-  backend "s3" {}
+  # State is stored in HCP Terraform. The workspace runs in Local execution
+  # mode: HCP Terraform holds the state, plan/apply still run locally.
+  # Authentication comes from `terraform login app.terraform.io`; no token is
+  # ever written into this file.
+  cloud {
+    organization = "gabor-toth-personalprojects"
+
+    workspaces {
+      name = "itassetpulse-ecs"
+    }
+  }
 }

--- a/infra/terraform/ecs/remote_state.tf
+++ b/infra/terraform/ecs/remote_state.tf
@@ -1,33 +1,45 @@
 # First stack in this repo to read another stack's remote state: foundation
 # and data (core increment, #180), plus account (observability increment,
 # #181 - the SNS topic ARN consumed by the alarms in observability.tf).
+#
+# The upstream states live in HCP Terraform (#203). A terraform_remote_state
+# data source reads HCP Terraform through the "remote" backend - there is no
+# "cloud" backend for this data source. Each producer workspace grants this
+# workspace access explicitly via its remote-state consumer list; no
+# organization- or project-wide state sharing is enabled.
 
 data "terraform_remote_state" "foundation" {
-  backend = "s3"
+  backend = "remote"
 
   config = {
-    bucket = var.state_bucket
-    key    = "itassetpulse/demo/foundation.tfstate"
-    region = var.aws_region
+    organization = "gabor-toth-personalprojects"
+
+    workspaces = {
+      name = "itassetpulse-foundation"
+    }
   }
 }
 
 data "terraform_remote_state" "data" {
-  backend = "s3"
+  backend = "remote"
 
   config = {
-    bucket = var.state_bucket
-    key    = "itassetpulse/demo/data.tfstate"
-    region = var.aws_region
+    organization = "gabor-toth-personalprojects"
+
+    workspaces = {
+      name = "itassetpulse-data"
+    }
   }
 }
 
 data "terraform_remote_state" "account" {
-  backend = "s3"
+  backend = "remote"
 
   config = {
-    bucket = var.state_bucket
-    key    = "itassetpulse/global/account.tfstate"
-    region = var.aws_region
+    organization = "gabor-toth-personalprojects"
+
+    workspaces = {
+      name = "itassetpulse-account"
+    }
   }
 }

--- a/infra/terraform/ecs/variables.tf
+++ b/infra/terraform/ecs/variables.tf
@@ -27,11 +27,6 @@ variable "aws_region" {
   default     = "eu-north-1"
 }
 
-variable "state_bucket" {
-  description = "Name of the S3 bucket created by the bootstrap stack, used to read the foundation and data stacks' remote state. Contains the AWS account ID, so it is never hardcoded or defaulted here (spec §8)."
-  type        = string
-}
-
 variable "release_sha" {
   description = "Full Git commit SHA of the backend/frontend images published by publish-images.yml. Used as the ECR image_tag for the digest lookup; no fallback tag is accepted."
   type        = string

--- a/infra/terraform/environments/demo/ecs.tfvars.example
+++ b/infra/terraform/environments/demo/ecs.tfvars.example
@@ -3,10 +3,6 @@ project_name = "itassetpulse"
 environment  = "demo"
 aws_region   = "eu-north-1" # example — confirm per spec §16
 
-# Name of the bucket created by the bootstrap stack (contains the AWS account
-# ID; never hardcoded in .tf, see variables.tf):
-state_bucket = "<your-terraform-state-bucket>"
-
 # Full Git commit SHA of the images published by publish-images.yml (spec §10.2):
 release_sha = "<git-commit-sha>"
 

--- a/infra/terraform/foundation/README.md
+++ b/infra/terraform/foundation/README.md
@@ -1,6 +1,14 @@
 # stack: foundation (remote state, ephemeral)
 
-Platform-agnostic base for compute. Spec: §4.3. State key: `itassetpulse/demo/foundation.tfstate`.
+Platform-agnostic base for compute. Spec: §4.3.
+State: HCP Terraform workspace `itassetpulse-foundation` (organization `gabor-toth-personalprojects`),
+Local execution mode. Cleanly initialized against HCP Terraform in #203; the former S3 state was verified
+empty beforehand and is a retained historical recovery copy only (retired by #209).
+
+> **This workspace has no state snapshot yet.** `terraform state list` therefore exits `1` with
+> `No state file was found!` rather than exiting `0` with no output — the workspace has *never* had a state
+> version, which is different from holding an empty one. That is expected and must not be "repaired": no
+> artificial empty state was uploaded. The first real `terraform apply` creates the first state version.
 
 ## What it creates
 
@@ -24,10 +32,10 @@ Platform-agnostic base for compute. Spec: §4.3. State key: `itassetpulse/demo/f
 ## Order
 
 ```bash
+terraform login app.terraform.io                                    # once per machine
 cd infra/terraform/foundation
-cp backend.hcl.example backend.hcl                                  # fill in the bootstrap-created bucket
 cp ../environments/demo/foundation.tfvars.example ../environments/demo/foundation.tfvars
-terraform init -backend-config=backend.hcl
+terraform init                                                      # cloud block; no -backend-config
 terraform plan  -var-file=../environments/demo/foundation.tfvars -out=tfplan
 terraform apply "tfplan"
 ```

--- a/infra/terraform/foundation/backend.hcl.example
+++ b/infra/terraform/foundation/backend.hcl.example
@@ -1,7 +1,0 @@
-# foundation — S3 remote backend (partial config).
-# Copy to backend.hcl (git-ignored) and set the bucket created by the bootstrap stack.
-bucket       = "<your-terraform-state-bucket>"
-key          = "itassetpulse/demo/foundation.tfstate"
-region       = "<your-aws-region>"
-encrypt      = true
-use_lockfile = true

--- a/infra/terraform/foundation/backend.tf
+++ b/infra/terraform/foundation/backend.tf
@@ -1,5 +1,13 @@
 terraform {
-  # Partial configuration: real values come from backend.hcl (git-ignored),
-  # supplied via `terraform init -backend-config=backend.hcl`.
-  backend "s3" {}
+  # State is stored in HCP Terraform. The workspace runs in Local execution
+  # mode: HCP Terraform holds the state, plan/apply still run locally.
+  # Authentication comes from `terraform login app.terraform.io`; no token is
+  # ever written into this file.
+  cloud {
+    organization = "gabor-toth-personalprojects"
+
+    workspaces {
+      name = "itassetpulse-foundation"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

* replace the S3 backend configuration for `account`, `foundation`, `data` and `ecs` with HCP Terraform `cloud` blocks
* configure the ECS upstream state reads through the corresponding HCP Terraform workspaces
* remove the obsolete ECS `state_bucket` input and its example value
* migrate the existing `account` state to HCP Terraform
* initialize the empty `foundation`, `data` and `ecs` workspaces
* update the infrastructure documentation and the HCP Terraform migration runbook
* retire the obsolete local `backend.hcl` files and the two legacy saved plans

All four migrated roots use **Local execution mode**: HCP Terraform stores the state and its history, while
`plan` and `apply` still run locally. `bootstrap` is not migrated and keeps local state.

## Workspace mapping

| Root | HCP workspace | Execution mode |
|---|---|---|
| `account` | `itassetpulse-account` | Local |
| `foundation` | `itassetpulse-foundation` | Local |
| `data` | `itassetpulse-data` | Local |
| `ecs` | `itassetpulse-ecs` | Local |
| `bootstrap` | — (local state, not migrated) | — |

Remote-state sharing is least-privilege: `account`, `foundation` and `data` each list `itassetpulse-ecs` as
their only consumer; `itassetpulse-ecs` shares its state with nobody. No project-wide or organization-wide
sharing is enabled.

## State migration evidence

* Terraform CLI **1.10.5** was used for every state-touching command, pinned deliberately so this change
  moves the backend only and does not also perform a CLI or state-format upgrade. The release checksum was
  verified against HashiCorp's published `SHA256SUMS` before the binary was executed.
* The `account` migration preserved all **seven** managed-resource addresses and all **five** data-source
  addresses. The sorted managed-address lists are identical before and after.
* The HCP `account` state is **finalized** and is now the single active and authoritative backend for that
  root.
* `foundation`, `data` and `ecs` remain empty. They have **no state version at all** — no artificial empty
  state was uploaded or created. Their first real `apply` will create the first state version.
* ECS-to-`account` remote-state access was verified with a **targeted, read-only** plan that evaluated
  exactly one data source, `data.terraform_remote_state.account`, with no AWS credentials available.
* The `sns_topic_arn` output **key** was verified as present; its **value** was never selected, displayed or
  persisted.
* **No AWS infrastructure mutation occurred during #203.** The only AWS interactions were reads.

Note on state metadata: HCP Terraform established a new workspace-local lineage and its own state-version
serial sequence for the previously empty workspace. Cross-backend lineage equality and continuation of the
S3 serial are **not** part of what the CLI migration workflow promises, and were removed as acceptance
assumptions. The HCP lineage was stable and the HCP serial non-decreasing across every later observation.

## Known drift — deferred to #207

* The post-migration `account` refresh found that `aws_iam_openid_connect_provider.github_actions[0]` is
  **already absent from AWS** — it was removed out-of-band.
* Configuration and state still intentionally contain that resource, so Terraform would currently propose
  **re-creating** it, plus an in-place update of the dependent `aws_iam_role.image_publish`. No destroy and
  no replacement is proposed.
* The `account` plan therefore returns detailed exit code **`2`**. This is **not** a no-op plan, and it was
  **not** caused by the backend migration — the same plan would have produced it against the S3 backend.
* **No apply was performed.**
* This drift is intentionally deferred to **#207**, which resolves it by removing the resource from the
  configuration. **This PR must not recreate the provider**, and it does not: `account/oidc.tf`,
  `account/iam.tf`, `account/variables.tf` and `account/terraform.tfvars.example` are byte-identical to the
  baseline, and `create_oidc_provider` is untouched.

## Remaining scope

* `bootstrap` remains on local state and is unchanged by this PR.
* The historical S3 state objects are retained as recovery copies only. They were not read or written after
  the migration and have **not** been deleted.
* Retiring the S3 bucket and the `bootstrap` stack remains **#209**.

## Verification

* Credential-free clean-clone reproduction of all six Terraform CI jobs — `fmt -check -recursive`,
  `init -backend=false` and `validate` — passed for `bootstrap`, `account`, `foundation`, `data`, `ecs` and
  `modules/ecs-fargate-service`. The environment was cleared with `env -i` and an empty `HOME`: no AWS
  credentials, no `TF_TOKEN_*`, no `TF_CLOUD_*`, no local Terraform credential file. `-backend=false`
  demonstrably skips HCP Terraform initialization, so CI needs neither AWS nor HCP Terraform credentials and
  `ci.yml` is unchanged.
* All tracked `.terraform.lock.hcl` files are unchanged; every `init` used `-lockfile=readonly`.
* `git diff --check` passes over the full baseline-to-HEAD range.
* Targeted sensitive-data scans over the complete diff found zero AWS access-key formats, account IDs,
  ARNs, credentials, tokens, private-key headers, e-mail addresses, IP addresses, bucket names, absolute
  local paths or usernames.
* The branch contains no Terraform state, saved plan, credential, ignored backend, tfvars, evidence, backup
  or `.terraform` artifact.

The GitHub Actions result for this PR is not yet known at the time of writing; only the local
credential-free reproduction has run.

## Issue links

Closes #203

* **#207** — remove the superseded GitHub Actions OIDC provider and the old image-publish path; resolves the
  drift described above.
* **#209** — retire the S3 state bucket and the `bootstrap` stack.
